### PR TITLE
Fixed seconds unit of progress to english

### DIFF
--- a/Notification.Wpf/Classes/OperationTimer.cs
+++ b/Notification.Wpf/Classes/OperationTimer.cs
@@ -104,7 +104,7 @@ namespace Notifications.Wpf.Classes
             return time is null ? BaseWaitingMessage ?? "" :
                 time.Value.Days > 0 ? time.Value.ToString(@"d\.hh\:mm\:ss") :
                 time.Value.Hours > 0 ? time.Value.ToString(@"hh\:mm\:ss") :
-                time.Value.Minutes > 0 ? time.Value.ToString(@"mm\:ss") : $"{Math.Round(time.Value.TotalSeconds, 0)} c";
+                time.Value.Minutes > 0 ? time.Value.ToString(@"mm\:ss") : $"{Math.Round(time.Value.TotalSeconds, 0)} s";
         }
         #region IDisposable
 


### PR DESCRIPTION
I assume 'c' is used here because of 'секунды' (Sorry if wrong but I've used Google translate). To be more international, 's' would be better here. Even better would be some kind of template but this is at least a start here.