### PR TITLE
hide alt+tab toastwindow

### DIFF
--- a/Notification.Wpf/Base/NotificationsOverlayWindow.xaml.cs
+++ b/Notification.Wpf/Base/NotificationsOverlayWindow.xaml.cs
@@ -1,4 +1,7 @@
-﻿using System.Windows;
+﻿using System;
+using System.Windows;
+using System.Windows.Interop;
+using System.Runtime.InteropServices;
 using Notification.Wpf.Constants;
 using Notification.Wpf.Controls;
 
@@ -53,10 +56,87 @@ namespace Notification.Wpf
         public bool CollapseProgressAutoIfMoreMessages { get => (bool)GetValue(CollapseProgressAutoIfMoreMessagesProperty); set => SetValue(CollapseProgressAutoIfMoreMessagesProperty, value); }
 
         #endregion
+
+        #region Window styles : hide alt+tab toastwindow
+
+        [Flags]
+        public enum ExtendedWindowStyles
+        {
+            // ...
+            WS_EX_TOOLWINDOW = 0x00000080,
+            // ...
+        }
+
+        public enum GetWindowLongFields
+        {
+            // ...
+            GWL_EXSTYLE = (-20),
+            // ...
+        }
+
+        [DllImport("user32.dll")]
+        public static extern IntPtr GetWindowLong(IntPtr hWnd, int nIndex);
+
+        public static IntPtr SetWindowLong(IntPtr hWnd, int nIndex, IntPtr dwNewLong)
+        {
+            int error = 0;
+            IntPtr result = IntPtr.Zero;
+            // Win32 SetWindowLong doesn't clear error on success
+            SetLastError(0);
+
+            if (IntPtr.Size == 4)
+            {
+                // use SetWindowLong
+                Int32 tempResult = IntSetWindowLong(hWnd, nIndex, IntPtrToInt32(dwNewLong));
+                error = Marshal.GetLastWin32Error();
+                result = new IntPtr(tempResult);
+            }
+            else
+            {
+                // use SetWindowLongPtr
+                result = IntSetWindowLongPtr(hWnd, nIndex, dwNewLong);
+                error = Marshal.GetLastWin32Error();
+            }
+
+            if ((result == IntPtr.Zero) && (error != 0))
+            {
+                throw new System.ComponentModel.Win32Exception(error);
+            }
+
+            return result;
+        }
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr", SetLastError = true)]
+        private static extern IntPtr IntSetWindowLongPtr(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+        [DllImport("user32.dll", EntryPoint = "SetWindowLong", SetLastError = true)]
+        private static extern Int32 IntSetWindowLong(IntPtr hWnd, int nIndex, Int32 dwNewLong);
+
+        private static int IntPtrToInt32(IntPtr intPtr)
+        {
+            return unchecked((int)intPtr.ToInt64());
+        }
+
+        [DllImport("kernel32.dll", EntryPoint = "SetLastError")]
+        public static extern void SetLastError(int dwErrorCode);
+
+        #endregion
+
         public NotificationsOverlayWindow()
         {
             InitializeComponent();
+            this.Loaded += NotificationsOverlayWindow_Loaded;
         }
-        
+
+        private void NotificationsOverlayWindow_Loaded(object sender, RoutedEventArgs e)
+        {
+            WindowInteropHelper wndHelper = new WindowInteropHelper(this);
+
+            int exStyle = (int)GetWindowLong(wndHelper.Handle, (int)GetWindowLongFields.GWL_EXSTYLE);
+
+            exStyle |= (int)ExtendedWindowStyles.WS_EX_TOOLWINDOW;
+
+            SetWindowLong(wndHelper.Handle, (int)GetWindowLongFields.GWL_EXSTYLE, (IntPtr)exStyle);
+        }
     }
 }


### PR DESCRIPTION
I found that if you do not specify areaName, a transparent toastWindow window will be displayed when toggling with alt+tab. I did a google search and found a way to hide the toastWindow window

> 我发现如果不指定areaName，在使用alt+tab窗口切换的时候，会显示出一个透明的toastWindow窗口，我通过google搜索，发现了这个隐藏toastWindow窗口的方法

https://stackoverflow.com/questions/357076/best-way-to-hide-a-window-from-the-alt-tab-program-switcher/551847#551847
https://www.cnblogs.com/lindexi/p/12086538.html
https://blog.csdn.net/qq452626100/article/details/52314283

![image](https://user-images.githubusercontent.com/28080853/218016494-64e73913-0fae-4f74-bdcd-2889dda036bd.png)
