### PR TITLE
Increase alpha of buttons and add border to improve visibility

### DIFF
--- a/Notification.Wpf/Converters/ColorAlphaConverter.cs
+++ b/Notification.Wpf/Converters/ColorAlphaConverter.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Globalization;
+using System.Windows.Data;
+using System.Windows.Markup;
+using System.Windows.Media;
+
+namespace Notification.Wpf.Converters
+{
+    [ValueConversion(typeof(Brush), typeof(double)), MarkupExtensionReturnType(typeof(ColorAlphaConverter))]
+    internal class ColorAlphaConverter : ValueConverter
+    {
+        /// <inheritdoc />
+        public override object Convert(object v, Type t, object p, CultureInfo c)
+        {
+            if (v is Brush convertBrush)
+            {
+                var copy = convertBrush.Clone();
+                copy.Opacity = 0.2;
+                return copy;
+            }
+            return v;
+        }
+
+        public override object ConvertBack(object v, Type t, object p, CultureInfo c) => throw new NotSupportedException();
+    }
+}
+

--- a/Notification.Wpf/Themes/Generic.xaml
+++ b/Notification.Wpf/Themes/Generic.xaml
@@ -166,7 +166,7 @@
 
     <Style TargetType="Button" x:Key="NotifyButton">
         <Setter Property="Foreground" Value="White"/>
-        <Setter Property="Background" Value="#22FFFFFF"/>
+        <Setter Property="Background" Value="#44FFFFFF"/>
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type Button}">
@@ -174,10 +174,12 @@
                            Foreground="{TemplateBinding Foreground}"
                            Background="{TemplateBinding Background}"
                            HorizontalContentAlignment="Center"
-                           MinWidth="80"  MaxWidth="120"/>
+                           MinWidth="80"  MaxWidth="120"
+                           BorderBrush="{TemplateBinding Foreground, Converter={converters:ColorAlphaConverter}}"
+                           BorderThickness="1"/>
                     <ControlTemplate.Triggers>
                         <Trigger Property="IsMouseOver" Value="True">
-                            <Setter Property="Background" Value="#11FFFFFF"/>
+                            <Setter Property="Background" Value="#22FFFFFF"/>
                         </Trigger>
                         <Trigger Property="IsPressed" Value="True">
                             <Setter Property="Background" Value="#11000000"/>


### PR DESCRIPTION
A PR is perhaps address my issue I raised here #57

I thought that raising the alpha value of the button slightly allows for it to become much clearer and noticeable. I also added a border that would be the same color as the Foreground with a low alpha to make it subtle but noticeable when using black text.

Some Examples with change:
![Screenshot 2023-07-10 115702](https://github.com/Platonenkov/Notification.Wpf/assets/43393284/f1a2b140-a480-428f-819d-e22a86ac2a68)
![Screenshot 2023-07-10 115739](https://github.com/Platonenkov/Notification.Wpf/assets/43393284/f764cc03-103b-4daa-a49d-a589cc3aa591)
![Screenshot 2023-07-10 120011](https://github.com/Platonenkov/Notification.Wpf/assets/43393284/ee4d3b9a-0810-4281-a3ff-421129a078af)


Would be great to get feedback!