### PR TITLE
Allow NotificationAreas to be removed from NotificationManager when Unloaded

### DIFF
--- a/Notification.Wpf/Base/NotificationManager.cs
+++ b/Notification.Wpf/Base/NotificationManager.cs
@@ -380,5 +380,6 @@ namespace Notification.Wpf
         }
 
         internal static void AddArea(NotificationArea area) => Areas.Add(area);
+        internal static void RemoveArea(NotificationArea area) => Areas.Remove(area);
     }
 }

--- a/Notification.Wpf/Controls/NotificationArea.cs
+++ b/Notification.Wpf/Controls/NotificationArea.cs
@@ -87,7 +87,18 @@ namespace Notification.Wpf.Controls
 
         public NotificationArea()
         {
+            Loaded += NotificationArea_Loaded;
+            Unloaded += NotificationArea_Unloaded;
+        }
+
+        private void NotificationArea_Loaded(object sender, RoutedEventArgs e)
+        {
             NotificationManager.AddArea(this);
+        }
+
+        private void NotificationArea_Unloaded(object sender, RoutedEventArgs e)
+        {
+            NotificationManager.RemoveArea(this);
         }
 
         static NotificationArea()


### PR DESCRIPTION
This change allows NotificationAreas to be removed from the NotificationManager's `Areas` list when they are unloaded.
This allowing these controls and their parents to be garbage collected, as previously this reference would prevent them from being collected as described in #61.