### PR TITLE
Fix null object error on notification close

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -17,6 +17,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 8.0.x
+
+      - name: Update the Version Number
+        run: |
+          (Get-Content Notification.Wpf\Notification.Wpf.csproj) -Replace '<Version>*.{7}</Version>', '<Version>${{ vars.StableVersion }}.0</Version>' | Set-Content Notification.Wpf\Notification.Wpf.csproj
         
       - name: Building
         run: dotnet build Notification.Wpf\Notification.Wpf.csproj -c Release

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -20,7 +20,7 @@ jobs:
 
       - name: Update the Version Number
         run: |
-          (Get-Content Notification.Wpf\Notification.Wpf.csproj) -Replace '<Version>*.{7}</Version>', '<Version>${{ vars.StableVersion }}.0</Version>' | Set-Content Notification.Wpf\Notification.Wpf.csproj
+          (Get-Content Notification.Wpf\Notification.Wpf.csproj) -Replace '<Version>*.{7}</Version>', '<Version>${{ vars.STABLEVERSION }}.0</Version>' | Set-Content Notification.Wpf\Notification.Wpf.csproj
         
       - name: Building
         run: dotnet build Notification.Wpf\Notification.Wpf.csproj -c Release
@@ -30,12 +30,22 @@ jobs:
           dotnet build Notification.Wpf/Notification.Wpf.csproj -c Release
           dotnet pack Notification.Wpf/Notification.Wpf.csproj -c Release
 
-      - name: Publish GitHub
-        run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
-          dotnet nuget push "**/*.snupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
+      # - name: Publish NuGet
+      #   run: |
+      #     dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_TOKEN }} 
+      #     dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_TOKEN }}
 
-      - name: Publish NuGet
+      - name: NuGet login (OIDC ? temp API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ secrets.NUGET_USER }}
+
+      - name: push to NuGet
+        shell: pwsh
         run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }} 
-          dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
+          Get-ChildItem artifacts/package/release -Filter *.nupkg | ForEach-Object {
+            dotnet nuget push $_.FullName `
+              --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" `
+              --source https://api.nuget.org/v3/index.json
+          }

--- a/Notification.Wpf/Controls/NotificationArea.cs
+++ b/Notification.Wpf/Controls/NotificationArea.cs
@@ -15,6 +15,8 @@ namespace Notification.Wpf.Controls
 {
     public class NotificationArea : Control
     {
+        private Window _overlayWindow = null;
+
         #region CollapseProgressAuto : bool - Progress bar will automatically collapsed if items count more that max items
 
         /// <summary>Progress bar will automatically collapsed if items count more that max items</summary>
@@ -174,7 +176,7 @@ namespace Notification.Wpf.Controls
             catch (OperationCanceledException)
             { }
             if (!notification.IsClosing)
-                notification.Close();
+                notification.Close(_overlayWindow);
         }
 
         /// <summary>
@@ -189,8 +191,8 @@ namespace Notification.Wpf.Controls
             if (!IsLoaded)
                 return;
 
-            var w = Window.GetWindow(this);
-            var x = PresentationSource.FromVisual(w);
+            _overlayWindow = Window.GetWindow(this);
+            var x = PresentationSource.FromVisual(_overlayWindow);
             if (x == null)
                 return;
             lock (_items)
@@ -213,7 +215,7 @@ namespace Notification.Wpf.Controls
                             }
                         }
 
-                    //_items.OfType<Notification>().Where(i=>i.DataContext is not NotificationProgress).First(i => !i.IsClosing).Close();
+                    //_items.OfType<Notification>().Where(i=>i.DataContext is not NotificationProgress).First(i => !i.IsClosing).Close(_overlayWindow);
                 }
             }
 
@@ -231,7 +233,7 @@ namespace Notification.Wpf.Controls
             await Task.Delay((TimeSpan)expirationTime);
 
 #endif
-            notification.Close();
+            notification.Close(_overlayWindow);
 #if NET40
             });
 #endif

--- a/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
+++ b/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
@@ -79,7 +79,7 @@ namespace Notification.Wpf.Controls
         }
 
         //TODO: .NET40
-        public async void Close()
+        public async void Close(Window overlayWindow = null)
         {
             if (IsClosing)
             {
@@ -92,7 +92,18 @@ namespace Notification.Wpf.Controls
             await Task.Delay(_closingAnimationTime);
             RaiseEvent(new RoutedEventArgs(NotificationClosedEvent));
 
-            var currentWindow = Application.Current?.Windows.OfType<Window>().FirstOrDefault(x => x.Title.Equals("ToastWindow"));
+            Window currentWindow = null;
+
+            string overlayWindowName = "ToastWindow";
+            if (overlayWindow != null)
+                if (overlayWindow.Name == overlayWindowName)
+                    currentWindow = overlayWindow;
+            try
+            {
+                if (currentWindow == null && Application.Current != null)
+                    currentWindow = Application.Current.Windows.OfType<Window>().FirstOrDefault(x => x.Title.Equals(overlayWindowName));
+            }
+            catch (Exception) { }
             if (currentWindow == null) return;
             var notificationCount = VisualTreeHelperExtensions.GetActiveNotificationCount(currentWindow);
 

--- a/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
+++ b/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
@@ -96,7 +96,7 @@ namespace Notification.Wpf.Controls
 
             string overlayWindowName = "ToastWindow";
             if (overlayWindow != null)
-                if (overlayWindow.Name == overlayWindowName)
+                if (overlayWindow.Title == overlayWindowName)
                     currentWindow = overlayWindow;
             try
             {

--- a/Notification.Wpf/Notification.Wpf.csproj
+++ b/Notification.Wpf/Notification.Wpf.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net8.0-windows;net7.0-windows;net6.0-windows;net5.0-windows;netcoreapp3.1-windows;net4.6-windows;net4.6.1-windows;net4.7-windows;net4.8-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
-    <Version>8.0.0.0</Version>
+    <Version>1.0.0.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/Notification.Wpf/Notification.Wpf.csproj
+++ b/Notification.Wpf/Notification.Wpf.csproj
@@ -32,6 +32,7 @@
     <PackageTags>Toast Notifications WPF</PackageTags>
     <PackageReleaseNotes>.net8 support</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <AssemblyName>Notification.Wpf.Swx</AssemblyName>
   </PropertyGroup>
 
 

--- a/Notification.Wpf/Notification.Wpf.xml
+++ b/Notification.Wpf/Notification.Wpf.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <doc>
     <assembly>
-        <name>Notification.Wpf</name>
+        <name>Notification.Wpf.Swx</name>
     </assembly>
     <members>
         <member name="M:Notification.Wpf.Base.Interfaces.Base.IButtonMessageManager.ShowFilePopUpMessage(System.String,System.Boolean,System.Boolean,System.Nullable{System.TimeSpan},System.String,Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions,Notification.Wpf.Classes.NotificationImage,System.Boolean)">

--- a/Notification.Wpf/Notification.Wpf.xml
+++ b/Notification.Wpf/Notification.Wpf.xml
@@ -370,6 +370,13 @@
         <member name="P:Notification.Wpf.NotificationsOverlayWindow.CollapseProgressAutoIfMoreMessages">
             <summary>Need collapse notification if count more that maximum</summary>
         </member>
+        <member name="M:Notification.Wpf.NotificationsOverlayWindow.NotificationsOverlayWindow_Loaded(System.Object,System.Windows.RoutedEventArgs)">
+            <summary>
+            hide window from taskbar
+            </summary>
+            <param name="sender"></param>
+            <param name="e"></param>
+        </member>
         <member name="M:Notification.Wpf.NotificationsOverlayWindow.InitializeComponent">
             <summary>
             InitializeComponent
@@ -700,14 +707,17 @@
         <member name="P:Notification.Wpf.Controls.Notification.XbtnVisibility">
             <summary>X Button visibility</summary>
         </member>
+        <member name="M:Notification.Wpf.Converters.ColorAlphaConverter.Convert(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
+            <inheritdoc />
+        </member>
         <member name="T:Notification.Wpf.Combine">
-            <summary>Конвертер, последовательно комбинирующий действия двух других конвертеров</summary>
+            <summary>Êîíâåðòåð, ïîñëåäîâàòåëüíî êîìáèíèðóþùèé äåéñòâèÿ äâóõ äðóãèõ êîíâåðòåðîâ</summary>
         </member>
         <member name="P:Notification.Wpf.Combine.First">
-            <summary>Первый применяемый конвертер</summary>
+            <summary>Ïåðâûé ïðèìåíÿåìûé êîíâåðòåð</summary>
         </member>
         <member name="P:Notification.Wpf.Combine.Then">
-            <summary>Второй применяемый конвертер</summary>
+            <summary>Âòîðîé ïðèìåíÿåìûé êîíâåðòåð</summary>
         </member>
         <member name="M:Notification.Wpf.DoubleValueConverter.Convert(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
             <inheritdoc />
@@ -792,7 +802,7 @@
         <member name="P:Notifications.Wpf.Classes.OperationTimer.BaseWaitingMessage">
             <summary> Base waiting message, will show when calculation </summary>
         </member>
-        <member name="F:Notifications.Wpf.Classes.OperationTimer.Watch">
+        <member name="P:Notifications.Wpf.Classes.OperationTimer.Watch">
             <summary> timer </summary>
         </member>
         <member name="F:Notifications.Wpf.Classes.OperationTimer.LastSpan">
@@ -1758,6 +1768,36 @@
         </member>
         <member name="M:System.Windows.Forms.Taskbar.Show">
             <summary>Shows the taskbar.</summary>
+        </member>
+        <member name="T:XamlGeneratedNamespace.GeneratedInternalTypeHelper">
+            <summary>
+            GeneratedInternalTypeHelper
+            </summary>
+        </member>
+        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.CreateInstance(System.Type,System.Globalization.CultureInfo)">
+            <summary>
+            CreateInstance
+            </summary>
+        </member>
+        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.GetPropertyValue(System.Reflection.PropertyInfo,System.Object,System.Globalization.CultureInfo)">
+            <summary>
+            GetPropertyValue
+            </summary>
+        </member>
+        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.SetPropertyValue(System.Reflection.PropertyInfo,System.Object,System.Object,System.Globalization.CultureInfo)">
+            <summary>
+            SetPropertyValue
+            </summary>
+        </member>
+        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.CreateDelegate(System.Type,System.Object,System.String)">
+            <summary>
+            CreateDelegate
+            </summary>
+        </member>
+        <member name="M:XamlGeneratedNamespace.GeneratedInternalTypeHelper.AddEventHandler(System.Reflection.EventInfo,System.Object,System.Delegate)">
+            <summary>
+            AddEventHandler
+            </summary>
         </member>
     </members>
 </doc>

--- a/packages.config
+++ b/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net472" />
+  <package id="RestSharp" version="106.13.0" targetFramework="net472" />
+  <package id="WPLMNETClient.Framework" version="1.0.6" targetFramework="net472" />
+</packages>


### PR DESCRIPTION
This pull request solves a null Application.Current error when using Notification.Wpf in a WPF class library, but hosted in a non-WPF application (such as a WinForms application)

To fix this, the overlay window object (or "ToastWindow") is passed to Close method. Additionally, added a check for a null Application.Current property before attempting to get Window object.