### PR TITLE
v10.0.0 — tuple-free progress API, options objects, issue fixes, docs

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -28,20 +28,29 @@ jobs:
       - name: Install MAUI workloads
         run: dotnet workload install maui-windows android ios maccatalyst
 
-      - name: Restore
-        run: dotnet restore Notification.Wpf.sln
+      - name: Build Core
+        run: dotnet build src/Notification.Core/Notification.Core.csproj -c Release
 
-      - name: Build
-        run: dotnet build Notification.Wpf.sln -c Release --no-restore
+      - name: Build WPF
+        run: dotnet build src/Notification.Wpf/Notification.Wpf.csproj -c Release
+
+      - name: Build Console
+        run: dotnet build src/Notification.Console/Notification.Console.csproj -c Release
+
+      - name: Build Avalonia
+        run: dotnet build src/Notification.Avalonia/Notification.Avalonia.csproj -c Release
+
+      - name: Build MAUI
+        run: dotnet build src/Notification.Maui/Notification.Maui.csproj -c Release
 
       - name: Test Core
-        run: dotnet test Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release --no-build --verbosity minimal
+        run: dotnet test Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release --verbosity minimal
 
       - name: Test Console
-        run: dotnet test Tests/Notification.Console.Tests/Notification.Console.Tests.csproj -c Release --no-build --verbosity minimal
+        run: dotnet test Tests/Notification.Console.Tests/Notification.Console.Tests.csproj -c Release --verbosity minimal
 
       - name: Test WPF Adapters
-        run: dotnet test Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj -c Release --no-build --verbosity minimal
+        run: dotnet test Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj -c Release --verbosity minimal
 
       - name: Pack Core
         run: dotnet pack src/Notification.Core/Notification.Core.csproj -c Release --no-build

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches: [ master ]
 
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: windows-latest

--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -27,20 +27,8 @@ jobs:
       - name: Restore
         run: dotnet restore Notification.Wpf.sln
 
-      - name: Build Core
-        run: dotnet build src/Notification.Core/Notification.Core.csproj -c Release --no-restore
-
-      - name: Build WPF
-        run: dotnet build src/Notification.Wpf/Notification.Wpf.csproj -c Release --no-restore
-
-      - name: Build Console
-        run: dotnet build src/Notification.Console/Notification.Console.csproj -c Release --no-restore
-
-      - name: Build Avalonia
-        run: dotnet build src/Notification.Avalonia/Notification.Avalonia.csproj -c Release --no-restore
-
-      - name: Build MAUI
-        run: dotnet build src/Notification.Maui/Notification.Maui.csproj -c Release --no-restore
+      - name: Build
+        run: dotnet build Notification.Wpf.sln -c Release --no-restore
 
       - name: Test Core
         run: dotnet test Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release --no-build --verbosity minimal

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -12,7 +12,7 @@ permissions:
 
 concurrency:
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build-docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -30,6 +30,9 @@ jobs:
             9.0.x
             10.0.x
 
+      - name: Install MAUI workloads
+        run: dotnet workload install maui-windows android ios maccatalyst
+
       - name: Install DocFx
         run: dotnet tool install -g docfx
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ master, dev ]
 
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     runs-on: windows-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,11 +30,26 @@ jobs:
       - name: Install MAUI workloads
         run: dotnet workload install maui-windows android ios maccatalyst
 
-      - name: Restore
-        run: dotnet restore Notification.Wpf.sln
+      - name: Build Core
+        run: dotnet build src/Notification.Core/Notification.Core.csproj -c Release
 
-      - name: Build
-        run: dotnet build Notification.Wpf.sln -c Release --no-restore
+      - name: Build WPF
+        run: dotnet build src/Notification.Wpf/Notification.Wpf.csproj -c Release
+
+      - name: Build Console
+        run: dotnet build src/Notification.Console/Notification.Console.csproj -c Release
+
+      - name: Build Avalonia
+        run: dotnet build src/Notification.Avalonia/Notification.Avalonia.csproj -c Release
+
+      - name: Build MAUI
+        run: dotnet build src/Notification.Maui/Notification.Maui.csproj -c Release
+
+      - name: Build Tests
+        run: |
+          dotnet build Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release
+          dotnet build Tests/Notification.Console.Tests/Notification.Console.Tests.csproj -c Release
+          dotnet build Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj -c Release
 
       - name: Test Core
         run: dotnet test Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release --no-build --verbosity normal --logger "trx;LogFileName=core-results.trx"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,50 @@
+name: Tests
+
+on:
+  push:
+    branches: [ master, dev ]
+  pull_request:
+    branches: [ master, dev ]
+
+jobs:
+  test:
+    runs-on: windows-latest
+    name: Build & Test
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: |
+            8.0.x
+            9.0.x
+            10.0.x
+
+      - name: Install MAUI workloads
+        run: dotnet workload install maui-windows android ios maccatalyst
+
+      - name: Restore
+        run: dotnet restore Notification.Wpf.sln
+
+      - name: Build
+        run: dotnet build Notification.Wpf.sln -c Release --no-restore
+
+      - name: Test Core
+        run: dotnet test Tests/Notification.Core.Tests/Notification.Core.Tests.csproj -c Release --no-build --verbosity normal --logger "trx;LogFileName=core-results.trx"
+
+      - name: Test Console
+        run: dotnet test Tests/Notification.Console.Tests/Notification.Console.Tests.csproj -c Release --no-build --verbosity normal --logger "trx;LogFileName=console-results.trx"
+
+      - name: Test WPF Adapters
+        run: dotnet test Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj -c Release --no-build --verbosity normal --logger "trx;LogFileName=wpf-results.trx"
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: test-results
+          path: '**/TestResults/*.trx'
+          retention-days: 14

--- a/DocFx/Builder-API.md
+++ b/DocFx/Builder-API.md
@@ -114,6 +114,7 @@ service.Show(b => b
 |--------|-------------|
 | `OnClick(Action)` | Click callback |
 | `OnClose(Action)` | Close callback |
+| `OnRightClick(Action)` | Right-click callback |
 
 ### Other
 

--- a/DocFx/Builder-API.md
+++ b/DocFx/Builder-API.md
@@ -1,6 +1,7 @@
 # Builder API
 
-The Builder API works identically on all platforms via `NotificationBuilder`.
+The Builder API works identically on all platforms via `NotificationBuilder`. It is the recommended
+modern replacement for the long-parameter `Show(...)` overloads — see the [Migration Guide](Migration-Guide.md).
 
 ## Basic Usage
 
@@ -119,6 +120,7 @@ service.Show(b => b
 | Method | Description |
 |--------|-------------|
 | `WithIcon(object)` | Icon (platform-specific) |
+| `WithContent(object)` | Arbitrary platform-specific content — replaces the `Show(object content, ...)` overload |
 | `WithExtension(string key, object value)` | Platform-specific extensions |
 | `Build()` | Create `NotificationRequest` |
 
@@ -159,3 +161,22 @@ NotificationColor rgb = NotificationColor.FromRgb(33, 150, 243);
 // Implicit from string
 NotificationColor implicit = "#FF5722";
 ```
+
+## Custom Content
+
+`WithContent` displays an arbitrary platform-specific UI object (for example, a WPF control) instead
+of the standard title/message layout. It replaces the legacy `Show(object content, ...)` overload.
+
+```csharp
+StackPanel panel = new StackPanel();
+panel.Children.Add(new TextBlock { Text = "Custom UI" });
+panel.Children.Add(new ProgressBar { IsIndeterminate = true });
+
+service.Show(NotificationBuilder
+    .Create()
+    .WithContent(panel)
+    .NeverExpires()
+    .Build());
+```
+
+When `WithContent` is set, the title, message and related text options are ignored.

--- a/DocFx/Configuration.md
+++ b/DocFx/Configuration.md
@@ -66,6 +66,32 @@ NotificationConstants.MinWidth = 350D;
 NotificationConstants.MaxWidth = 350D;
 ```
 
+## WPF behavior settings (NotificationConstants only)
+
+These WPF-only static settings are **not** part of `INotificationConfiguration`. Set them once before
+showing notifications. All of them are opt-in — the defaults preserve the previous behavior.
+
+```csharp
+// Keep the notification open while the cursor is over it (issue #71).
+// The auto-close timer is paused on mouse-over and resumed on mouse-leave.
+NotificationConstants.KeepNotificationVisibleOnMouseOver = true;
+
+// Whether the toast overlay window stays on top of other windows (issue #65).
+NotificationConstants.OverlayWindowTopmost = false;
+
+// Rounded corners for the notification card (issue #52).
+NotificationConstants.NotificationCornerRadius = new CornerRadius(8);
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `KeepNotificationVisibleOnMouseOver` | `bool` | `false` | Pause the auto-close timer while the mouse is over the notification |
+| `OverlayWindowTopmost` | `bool` | `true` | Whether the toast overlay window stays on top of other windows |
+| `NotificationCornerRadius` | `CornerRadius` | `0` (square) | Corner radius of the notification card |
+
+> `NotificationCornerRadius` requires `using System.Windows;`. It is also exposed per notification
+> as the `Notification.CornerRadius` dependency property.
+
 ## Configuration Properties
 
 | Property | Type | Default | Description |

--- a/DocFx/Migration-Guide.md
+++ b/DocFx/Migration-Guide.md
@@ -1,0 +1,205 @@
+# Migration Guide
+
+Notification.Wpf **10.0** keeps **full backward compatibility** — all existing code keeps compiling
+and running. This guide shows how to move to the modern, clearer APIs.
+
+Two legacy APIs are now marked `[Obsolete]` (they still work, but the compiler emits a warning).
+Migrating away from them removes the warnings and makes call sites far easier to read.
+
+## Quick reference
+
+| Legacy API | Modern API | Status |
+|-----------|-----------|--------|
+| `progress.GetProgress<(double,string)>(...)` + tuple `Report((v, msg))` | `progress.Report(value, message)` | ⚠️ `[Obsolete]` |
+| `ShowProgressBar(...)` — 16 positional parameters | `ShowProgressBar(ProgressBarOptions)` | ⚠️ `[Obsolete]` |
+| `Show(...)` — up to 18 positional parameters | `NotificationBuilder` | ✅ still supported — Builder recommended |
+
+> The long-parameter `Show(...)` overloads are **not** deprecated — they keep working without warnings.
+> The [Builder API](Builder-API.md) is simply the recommended modern alternative.
+
+---
+
+## 1. Progress reporting — drop the tuples
+
+The old API exposed a fake-generic `GetProgress<T>()` that only accepted six hard-coded types
+(`double`, `int` and four tuple shapes) and threw `NotSupportedException` at runtime for anything else.
+
+**Before:**
+
+```csharp
+using var progress = manager.ShowProgressBar("Working...");
+
+IProgress<(double, string)> p = progress.GetProgress<(double, string)>(showCancel: true);
+p.Report((50.0, "half done"));
+```
+
+**After:**
+
+```csharp
+using var progress = manager.ShowProgressBar(new ProgressBarOptions { Title = "Working..." });
+
+progress.Report(50);                              // value only
+progress.Report(50, "half done");                 // value + message
+progress.Report(50, "half done", "Working");       // value + message + title
+progress.Report(50, "half done", "Working", true); // + cancel-button visibility
+progress.ReportIndeterminate("Waiting...");        // no numeric value
+```
+
+For a UI-agnostic calculation layer that must report plain numbers:
+
+```csharp
+IProgress<double> plain  = progress.GetValueProgress(showCancel: true, scale: true);
+IProgress<NotificationProgressReport> slowed = progress.GetSlowedProgress(updateTimeOut: 100);
+IProgress<double> slowedPlain = progress.GetSlowedValueProgress(updateTimeOut: 100);
+```
+
+📂 Working example: [`MainWindow.xaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs)
+
+---
+
+## 2. `ShowProgressBar` — 16 parameters → `ProgressBarOptions`
+
+The 16-parameter positional `ShowProgressBar(...)` overload is now `[Obsolete]`.
+
+**Before:**
+
+```csharp
+using var progress = manager.ShowProgressBar(
+    "Processing files", true, true, "MainArea", false, 1, "Calculation time",
+    true, true, Brushes.DarkSlateGray, Brushes.White, Brushes.LimeGreen, null, null, null, true);
+```
+
+**After:**
+
+```csharp
+using var progress = manager.ShowProgressBar(new ProgressBarOptions
+{
+    Title              = "Processing files",
+    ShowCancelButton   = true,
+    AreaName           = "MainArea",
+    IsCollapse         = true,
+    BaseWaitingMessage = "Calculation time",
+    BackgroundColor    = NotificationColor.FromHex("#2F4F4F"),
+    ForegroundColor    = NotificationColor.White,
+    ProgressColor      = NotificationColor.LimeGreen,
+});
+```
+
+Set only the properties you need — every property has a sensible default.
+
+### Parameter mapping
+
+| Legacy parameter | `ProgressBarOptions` property | Type change |
+|------------------|-------------------------------|-------------|
+| `Title` | `Title` | — |
+| `ShowCancelButton` | `ShowCancelButton` | — |
+| `ShowProgress` | `ShowProgress` | — |
+| `areaName` | `AreaName` | — |
+| `TrimText` | `TrimText` | — |
+| `DefaultRowsCount` | `DefaultRowsCount` | — |
+| `BaseWaitingMessage` | `BaseWaitingMessage` | — |
+| `IsCollapse` | `IsCollapse` | — |
+| `TitleWhenCollapsed` | `TitleWhenCollapsed` | — |
+| `background` | `BackgroundColor` | `Brush` → `NotificationColor?` |
+| `foreground` | `ForegroundColor` | `Brush` → `NotificationColor?` |
+| `progressColor` | `ProgressColor` | `Brush` → `NotificationColor?` |
+| `icon` | `Icon` | — |
+| `TitleSettings` | `TitleSettings` | `TextContentSettings` → `NotificationTextSettings` |
+| `MessageSettings` | `MessageSettings` | `TextContentSettings` → `NotificationTextSettings` |
+| `ShowXbtn` | `ShowCloseButton` | renamed |
+
+> The `ShowProgressBar(ICustomizedNotification content, ...)` overload (custom-content progress) is
+> **not** deprecated and keeps working unchanged.
+
+---
+
+## 3. `Show` — long parameter lists → `NotificationBuilder`
+
+The heaviest `Show(...)` overload takes **18 positional parameters**. The [Builder API](Builder-API.md)
+expresses the same notification with named, chainable methods. The legacy overloads still work — this
+migration is recommended, not required.
+
+**Before:**
+
+```csharp
+manager.Show("Update available", "Version 2.0 is ready", NotificationType.Information,
+    "MainArea", TimeSpan.FromSeconds(15), () => Log("clicked"), () => Log("closed"),
+    () => Install(), "Install", () => { }, "Later",
+    NotificationTextTrimType.Trim, 3, true, null, null, true, null);
+```
+
+**After:**
+
+```csharp
+manager.Show(NotificationBuilder
+    .Create("Update available", "Version 2.0 is ready")
+    .AsInformation()
+    .InArea("MainArea")
+    .ExpiresInSeconds(15)
+    .OnClick(() => Log("clicked"))
+    .OnClose(() => Log("closed"))
+    .WithLeftButton("Install", () => Install())
+    .WithRightButton("Later", () => { })
+    .WithTrimming(NotificationTextTrimType.Trim, 3)
+    .Build());
+```
+
+### Parameter mapping
+
+| Legacy parameter | Builder method |
+|------------------|----------------|
+| `title` | `Create(title, message)` or `WithTitle(title)` |
+| `message` | `WithMessage(message)` |
+| `type` | `OfType(type)` / `AsSuccess()` / `AsWarning()` / `AsError()` / `AsInformation()` |
+| `areaName` | `InArea(areaName)` |
+| `expirationTime` | `ExpiresIn(time)` / `ExpiresInSeconds(n)` / `NeverExpires()` |
+| `onClick` | `OnClick(action)` |
+| `onClose` | `OnClose(action)` |
+| `LeftButton` + `LeftButtonText` | `WithLeftButton(text, action)` |
+| `RightButton` + `RightButtonText` | `WithRightButton(text, action)` |
+| `trim` + `RowsCountWhenTrim` | `WithTrimming(trimType, rows)` |
+| `CloseOnClick` | `CloseOnClick(bool)` |
+| `TitleSettings` | `WithTitleSettings(s => ...)` |
+| `MessageSettings` | `WithMessageSettings(s => ...)` |
+| `ShowXbtn` (`false`) | `HideCloseButton()` |
+| `icon` | `WithIcon(icon)` |
+
+### Custom content — `Show(object content, ...)` → `WithContent(...)`
+
+```csharp
+// Before
+manager.Show(myCustomGrid, "MainArea", TimeSpan.MaxValue);
+
+// After
+manager.Show(NotificationBuilder
+    .Create()
+    .WithContent(myCustomGrid)
+    .InArea("MainArea")
+    .NeverExpires()
+    .Build());
+```
+
+### WPF-typed values (`Brush`, `ImageSource`)
+
+The Builder uses platform-agnostic types. To pass native WPF objects directly, use the WPF builder
+extensions from `Notification.Wpf.Builder`:
+
+```csharp
+manager.Show(NotificationBuilder
+    .Create("Title", "Message")
+    .WithBackground(Brushes.SteelBlue)            // WpfBuilderExtensions
+    .WithImage(myImageSource, ImagePosition.Top)   // WpfBuilderExtensions
+    .Build());
+```
+
+---
+
+## Working examples in the repository
+
+| Topic | File |
+|-------|------|
+| Builder API & migration examples | [`MainWindow.BuilderExamples.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs) |
+| Progress bar & `Report(...)` overloads | [`MainWindow.xaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs) |
+| Cross-platform progress (Avalonia) | [`MainWindow.axaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs) |
+
+See also: [Builder API reference](Builder-API.md) · [Getting Started](Getting-Started.md)

--- a/DocFx/index.md
+++ b/DocFx/index.md
@@ -42,6 +42,22 @@ service.Show(NotificationBuilder
     .Build());
 ```
 
+## Migrating from an earlier version?
+
+Version 10.0 is **fully backward compatible**. Two legacy APIs are now `[Obsolete]` and have clearer
+replacements — the [Migration Guide](Migration-Guide.md) covers them step by step:
+
+```csharp
+// Progress: tuple API  ->  Report(...) overloads
+progress.Report(50, "half done", "Working");
+
+// ShowProgressBar: 16 positional parameters  ->  ProgressBarOptions
+manager.ShowProgressBar(new ProgressBarOptions { Title = "Working...", ProgressColor = NotificationColor.LimeGreen });
+
+// Show: up to 18 positional parameters  ->  NotificationBuilder (the old overloads still work)
+manager.Show(NotificationBuilder.Create("Title", "Message").AsSuccess().ExpiresInSeconds(5).Build());
+```
+
 ## DI Registration
 
 ```csharp
@@ -96,12 +112,16 @@ xmlns:notifications="clr-namespace:Notification.Wpf.Controls;assembly=Notificati
 ### Progress Bar
 
 ```csharp
-using var progress = notificationManager.ShowProgressBar("Processing...", showCancelButton: true);
+using var progress = notificationManager.ShowProgressBar(new ProgressBarOptions
+{
+    Title            = "Processing...",
+    ShowCancelButton = true,
+});
 
 for (var i = 0; i <= 100; i++)
 {
     progress.Cancel.ThrowIfCancellationRequested();
-    progress.Report(new NotificationProgressReport(i, $"Step {i}", "With progress", true));
+    progress.Report(i, $"Step {i}", "With progress");   // tuple-free Report overload
     await Task.Delay(TimeSpan.FromSeconds(0.02), progress.Cancel).ConfigureAwait(false);
 }
 ```
@@ -143,6 +163,7 @@ On Windows, CommunityToolkit.Maui Snackbar uses native `AppNotification` (toast)
 | Guide | Description |
 |-------|-------------|
 | [Getting Started](Getting-Started.md) | Installation, DI registration, first notification |
+| [Migration Guide](Migration-Guide.md) | Upgrading: tuple progress, `ShowProgressBar` options, Builder API |
 | [Builder API](Builder-API.md) | Fluent builder reference with all methods |
 | [Configuration](Configuration.md) | INotificationConfiguration and NotificationConstants |
 | [Lifecycle Events](Lifecycle-Events.md) | Event tracking: Shown, Clicked, Closed, TimedOut, Dismissed |

--- a/DocFx/toc.yml
+++ b/DocFx/toc.yml
@@ -2,6 +2,8 @@
   href: index.md
 - name: Getting Started
   href: Getting-Started.md
+- name: Migration Guide
+  href: Migration-Guide.md
 - name: Builder API
   href: Builder-API.md
 - name: Configuration

--- a/Documentation.md
+++ b/Documentation.md
@@ -1,3 +1,77 @@
+<details open>
+  <br />
+  <summary><h2>🔄 Migration Guide (read this first if upgrading)</h2></summary>
+
+Version **10.0** is **fully backward compatible** — existing code keeps compiling and running.
+Two legacy APIs are now marked `[Obsolete]` (still functional, but the compiler warns). Migrate for
+cleaner call sites and to remove the warnings.
+
+| Legacy API | Modern API | Status |
+|-----------|-----------|--------|
+| `progress.GetProgress<(double,string)>(...)` + tuple `Report` | `progress.Report(value, message)` | ⚠️ `[Obsolete]` |
+| `ShowProgressBar(...)` — 16 positional parameters | `ShowProgressBar(ProgressBarOptions)` | ⚠️ `[Obsolete]` |
+| `Show(...)` — up to 18 positional parameters | `NotificationBuilder` | ✅ still supported, Builder recommended |
+
+### Progress reporting — tuples → `Report(...)` overloads
+
+```csharp
+// Before: fake-generic, tuple-typed
+IProgress<(double, string)> p = progress.GetProgress<(double, string)>(showCancel: true);
+p.Report((50.0, "half done"));
+
+// After: plain Report overloads
+progress.Report(50, "half done");                  // value + message
+progress.Report(50, "half done", "Working", true);  // + title + cancel-button flag
+progress.ReportIndeterminate("Waiting...");         // no numeric value
+```
+
+### `ShowProgressBar` — 16 parameters → `ProgressBarOptions`
+
+```csharp
+// Before: 16 positional parameters
+using var progress = manager.ShowProgressBar(
+    "Processing files", true, true, "MainArea", false, 1, "Calculation time",
+    true, true, Brushes.DarkSlateGray, Brushes.White, Brushes.LimeGreen, null, null, null, true);
+
+// After: a configurable options object — set only what you need
+using var progress = manager.ShowProgressBar(new ProgressBarOptions
+{
+    Title              = "Processing files",
+    AreaName           = "MainArea",
+    IsCollapse         = true,
+    BackgroundColor    = NotificationColor.FromHex("#2F4F4F"),
+    ProgressColor      = NotificationColor.LimeGreen,
+});
+```
+
+### `Show` — long parameter lists → `NotificationBuilder`
+
+```csharp
+// Before: up to 18 positional parameters with many `null`s
+manager.Show("Update available", "Version 2.0 is ready", NotificationType.Information,
+    "MainArea", TimeSpan.FromSeconds(15), null, null, () => Install(), "Install",
+    () => { }, "Later", NotificationTextTrimType.Trim, 3, true, null, null, true, null);
+
+// After: named, chainable Builder methods
+manager.Show(NotificationBuilder
+    .Create("Update available", "Version 2.0 is ready")
+    .AsInformation()
+    .InArea("MainArea")
+    .ExpiresInSeconds(15)
+    .WithLeftButton("Install", () => Install())
+    .WithRightButton("Later", () => { })
+    .WithTrimming(NotificationTextTrimType.Trim, 3)
+    .Build());
+
+// Arbitrary custom content: Show(object content, ...)  ->  WithContent(...)
+manager.Show(NotificationBuilder.Create().WithContent(myCustomGrid).NeverExpires().Build());
+```
+
+➡️ **Full step-by-step guide with complete before/after examples, parameter-mapping tables and links
+to working Sample code: [Migration.md](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md)**
+
+</details>
+
 <details>
   <br />
   <summary><h2>Initialization</h2></summary>
@@ -203,6 +277,7 @@ service.Show(b => b
 | `OnClick(Action)` | Click callback |
 | `OnClose(Action)` | Close callback |
 | `WithIcon(object)` | Icon (platform-specific) |
+| `WithContent(object)` | Arbitrary platform-specific content — replaces the `Show(object content, ...)` overload |
 | `WithExtension(string key, object value)` | Platform-specific extensions |
 | `Build()` | Create `NotificationRequest` |
 
@@ -252,7 +327,9 @@ var notificationManager = new NotificationManager();
 notificationManager.Show("Title", "Message", NotificationType.Success);
 ```
 
-[Message initialization methods](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Notification.Wpf/Base/Interfaces/Base/IMessageManager.cs)
+[Message initialization methods](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Wpf/Base/Interfaces/Base/IMessageManager.cs)
+
+> **Recommended:** use the Builder API instead of the long-parameter `Show(...)` overloads. See the [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md).
 
 </details>
 
@@ -261,23 +338,40 @@ notificationManager.Show("Title", "Message", NotificationType.Success);
   <summary><h2>Progress Bar</h2></summary>
 
 ```csharp
-using var progress = notificationManager.ShowProgressBar("Processing...", showCancelButton: true);
+using var progress = notificationManager.ShowProgressBar(new ProgressBarOptions
+{
+    Title            = "Processing...",
+    ShowCancelButton = true,
+});
 
 for (var i = 0; i <= 100; i++)
 {
     progress.Cancel.ThrowIfCancellationRequested();
-    progress.Report(new NotificationProgressReport(i, $"Step {i}", "With progress", true));
+    progress.Report(i, $"Step {i}", "With progress");   // tuple-free Report overload
     await Task.Delay(TimeSpan.FromSeconds(0.02), progress.Cancel).ConfigureAwait(false);
 }
 ```
 
-`NotificationProgressReport` fields:
+### `Report(...)` overloads
+
+| Call | Effect |
+|------|--------|
+| `progress.Report(value)` | Update progress value only |
+| `progress.Report(value, message)` | Value + status message |
+| `progress.Report(value, message, title)` | Value + message + title |
+| `progress.Report(value, message, title, showCancel)` | + cancel-button visibility |
+| `progress.ReportIndeterminate(message, title)` | Indeterminate progress (no numeric value) |
+
+`NotificationProgressReport` fields (the underlying struct):
 - `Value` (double?) — progress percentage (0-100), null hides the bar
 - `Message` (string) — status message
 - `Title` (string) — progress title
 - `ShowCancel` (bool?) — show/hide cancel button
 
-[Progress initialization methods](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Notification.Wpf/Base/Interfaces/Base/IProgressManager.cs)
+> The 16-parameter `ShowProgressBar(...)` overload and the tuple-based `GetProgress<T>` API are
+> `[Obsolete]`. See the [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md).
+
+[Progress initialization methods](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Wpf/Base/Interfaces/Base/IProgressManager.cs)
 
 </details>
 

--- a/Documentation.md
+++ b/Documentation.md
@@ -276,6 +276,7 @@ service.Show(b => b
 | `WithOkCancel(Action onOk, Action onCancel)` | OK/Cancel buttons |
 | `OnClick(Action)` | Click callback |
 | `OnClose(Action)` | Close callback |
+| `OnRightClick(Action)` | Right-click callback |
 | `WithIcon(object)` | Icon (platform-specific) |
 | `WithContent(object)` | Arbitrary platform-specific content — replaces the `Show(object content, ...)` overload |
 | `WithExtension(string key, object value)` | Platform-specific extensions |
@@ -439,6 +440,50 @@ NotificationConstants.InformationBackgroundColor = new SolidColorBrush(Colors.Co
 NotificationConstants.MessagePosition = NotificationPosition.BottomRight;
 NotificationConstants.MinWidth = 350D;
 NotificationConstants.MaxWidth = 350D;
+```
+
+### WPF behavior settings (NotificationConstants only)
+
+WPF-only static settings that are **not** part of `INotificationConfiguration`. Set them once before
+showing notifications — all are opt-in and the defaults preserve the previous behavior.
+
+```csharp
+// Keep the notification open while the cursor is over it — the auto-close timer
+// is paused on mouse-over and resumed on mouse-leave (issue #71). Default: false.
+NotificationConstants.KeepNotificationVisibleOnMouseOver = true;
+
+// Whether the toast overlay window stays on top of other windows (issue #65). Default: true.
+NotificationConstants.OverlayWindowTopmost = false;
+
+// Rounded corners for the notification card (issue #52). Default: new CornerRadius(0).
+NotificationConstants.NotificationCornerRadius = new CornerRadius(8);
+```
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `KeepNotificationVisibleOnMouseOver` | `bool` | `false` | Pause the auto-close timer while the mouse is over the notification |
+| `OverlayWindowTopmost` | `bool` | `true` | Whether the toast overlay window stays on top of other windows |
+| `NotificationCornerRadius` | `CornerRadius` | `0` (square) | Corner radius of the notification card |
+
+`NotificationCornerRadius` requires `using System.Windows;` and is also exposed per notification
+as the `Notification.CornerRadius` dependency property.
+
+### Right-click action
+
+```csharp
+// Builder API
+service.Show(NotificationBuilder
+    .Create("Title", "Message")
+    .OnRightClick(() => ShowContextMenu())
+    .Build());
+
+// Classic WPF — via NotificationContent
+var content = new NotificationContent
+{
+    Title = "Title",
+    Message = "Message",
+    RightClickAction = () => ShowContextMenu(),
+};
 ```
 
 </details>

--- a/Migration.md
+++ b/Migration.md
@@ -1,0 +1,265 @@
+# Migration Guide
+
+Notification.Wpf **10.0** keeps **full backward compatibility** — all existing code keeps compiling and running.
+This guide shows how to move to the modern, clearer APIs.
+
+Two legacy APIs are now marked `[Obsolete]` (they still work, but the compiler will emit a warning).
+Migrating away from them removes the warnings and makes call sites far easier to read.
+
+## Quick reference
+
+| Legacy API | Modern API | Status |
+|-----------|-----------|--------|
+| `progress.GetProgress<(double,string)>(...)` + tuple `Report((v, msg))` | `progress.Report(value, message)` | ⚠️ `[Obsolete]` |
+| `ShowProgressBar(...)` — 16 positional parameters | `ShowProgressBar(ProgressBarOptions)` | ⚠️ `[Obsolete]` |
+| `Show(...)` — up to 18 positional parameters | `NotificationBuilder` | ✅ still supported — Builder recommended |
+
+> **Note:** the long-parameter `Show(...)` overloads are **not** deprecated — they keep working without warnings.
+> The Builder API is simply the recommended modern alternative.
+
+---
+
+## 1. Progress reporting — drop the tuples
+
+The old API exposed a fake-generic `GetProgress<T>()` that only accepted six hard-coded types
+(`double`, `int` and four tuple shapes) and threw `NotSupportedException` at runtime for anything else.
+
+### Before
+
+```csharp
+using var progress = manager.ShowProgressBar("Working...");
+
+// fake-generic, tuple-typed, throws at runtime for unsupported T
+IProgress<(double, string)> p = progress.GetProgress<(double, string)>(showCancel: true);
+p.Report((50.0, "half done"));
+```
+
+### After
+
+```csharp
+using var progress = manager.ShowProgressBar(new ProgressBarOptions { Title = "Working..." });
+
+progress.Report(50);                              // value only
+progress.Report(50, "half done");                 // value + message
+progress.Report(50, "half done", "Working");       // value + message + title
+progress.Report(50, "half done", "Working", true); // + cancel-button visibility
+progress.ReportIndeterminate("Waiting...");        // no numeric value
+```
+
+`NotificationProgressReport` also gained immutable helpers:
+
+```csharp
+var report = NotificationProgressReport.Indeterminate("Waiting...");
+report = report.WithValue(75).WithMessage("Almost there");
+```
+
+### Keeping a UI-agnostic calculation layer
+
+If a calculation method must stay free of the notification library, report plain `double` values:
+
+```csharp
+// double progress, optional 0..1 -> 0..100 scaling, optional cancel flag
+IProgress<double> plain = progress.GetValueProgress(showCancel: true, scale: true);
+
+// throttled passthrough of full reports (one update per 100 ms)
+IProgress<NotificationProgressReport> slowed = progress.GetSlowedProgress(updateTimeOut: 100);
+
+// throttled plain double progress
+IProgress<double> slowedPlain = progress.GetSlowedValueProgress(updateTimeOut: 100);
+```
+
+The obsolete `GetProgress<T>` / `GetSlowedProgress<T>` still work — but prefer the methods above.
+
+📂 **Working example:** [`Samples/Notification.Wpf.Sample/MainWindow.xaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs) — see the progress demo and the `CalcAsync` methods.
+
+---
+
+## 2. `ShowProgressBar` — 16 parameters → `ProgressBarOptions`
+
+The 16-parameter positional `ShowProgressBar(...)` overload is now `[Obsolete]`.
+Replace it with `ShowProgressBar(ProgressBarOptions)`.
+
+### Before
+
+```csharp
+using var progress = manager.ShowProgressBar(
+    "Processing files",      // Title
+    true,                    // ShowCancelButton
+    true,                    // ShowProgress
+    "MainArea",              // areaName
+    false,                   // TrimText
+    1,                       // DefaultRowsCount
+    "Calculation time",      // BaseWaitingMessage
+    true,                    // IsCollapse
+    true,                    // TitleWhenCollapsed
+    Brushes.DarkSlateGray,   // background
+    Brushes.White,           // foreground
+    Brushes.LimeGreen,       // progressColor
+    null,                    // icon
+    null,                    // TitleSettings
+    null,                    // MessageSettings
+    true);                   // ShowXbtn
+```
+
+### After
+
+```csharp
+using var progress = manager.ShowProgressBar(new ProgressBarOptions
+{
+    Title              = "Processing files",
+    ShowCancelButton   = true,
+    AreaName           = "MainArea",
+    IsCollapse         = true,
+    BaseWaitingMessage = "Calculation time",
+    BackgroundColor    = NotificationColor.FromHex("#2F4F4F"),
+    ForegroundColor    = NotificationColor.White,
+    ProgressColor      = NotificationColor.LimeGreen,
+});
+```
+
+Only set the properties you actually need — every property has a sensible default.
+
+### Parameter mapping
+
+| Legacy parameter | `ProgressBarOptions` property | Type change |
+|------------------|-------------------------------|-------------|
+| `Title` | `Title` | — |
+| `ShowCancelButton` | `ShowCancelButton` | — |
+| `ShowProgress` | `ShowProgress` | — |
+| `areaName` | `AreaName` | — |
+| `TrimText` | `TrimText` | — |
+| `DefaultRowsCount` | `DefaultRowsCount` | — |
+| `BaseWaitingMessage` | `BaseWaitingMessage` | — |
+| `IsCollapse` | `IsCollapse` | — |
+| `TitleWhenCollapsed` | `TitleWhenCollapsed` | — |
+| `background` | `BackgroundColor` | `Brush` → `NotificationColor?` |
+| `foreground` | `ForegroundColor` | `Brush` → `NotificationColor?` |
+| `progressColor` | `ProgressColor` | `Brush` → `NotificationColor?` |
+| `icon` | `Icon` | — |
+| `TitleSettings` | `TitleSettings` | `TextContentSettings` → `NotificationTextSettings` |
+| `MessageSettings` | `MessageSettings` | `TextContentSettings` → `NotificationTextSettings` |
+| `ShowXbtn` | `ShowCloseButton` | renamed |
+
+**Colors:** `NotificationColor` is a lightweight platform-agnostic struct. Build one from a hex string
+(`NotificationColor.FromHex("#2F4F4F")`), RGB (`NotificationColor.FromRgb(47, 79, 79)`), a predefined
+color (`NotificationColor.LimeGreen`), or implicitly from a string (`NotificationColor c = "#2F4F4F";`).
+
+> The `ShowProgressBar(ICustomizedNotification content, ...)` overload (custom-content progress) is **not**
+> deprecated and keeps working unchanged.
+
+📄 **Source:** [`ProgressBarOptions.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Core/Models/ProgressBarOptions.cs) · [`IProgressManager.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Wpf/Base/Interfaces/Base/IProgressManager.cs)
+📂 **Working example:** [`MainWindow.BuilderExamples.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs) — `ShowProgressBarOptionsExample`
+
+---
+
+## 3. `Show` — long parameter lists → `NotificationBuilder`
+
+The heaviest `Show(...)` overload takes **18 positional parameters**. The Builder API expresses the
+same notification with named, discoverable, chainable methods. The legacy overloads still work — this
+migration is recommended, not required.
+
+### Before
+
+```csharp
+manager.Show(
+    "Update available",                 // title
+    "Version 2.0 is ready to install",  // message
+    NotificationType.Information,       // type
+    "MainArea",                         // areaName
+    TimeSpan.FromSeconds(15),           // expirationTime
+    () => Log("clicked"),               // onClick
+    () => Log("closed"),                // onClose
+    () => Install(),                    // LeftButton
+    "Install",                          // LeftButtonText
+    () => { },                          // RightButton
+    "Later",                            // RightButtonText
+    NotificationTextTrimType.Trim,      // trim
+    3,                                  // RowsCountWhenTrim
+    true,                               // CloseOnClick
+    null,                               // TitleSettings
+    null,                               // MessageSettings
+    true,                               // ShowXbtn
+    null);                              // icon
+```
+
+### After
+
+```csharp
+manager.Show(NotificationBuilder
+    .Create("Update available", "Version 2.0 is ready to install")
+    .AsInformation()
+    .InArea("MainArea")
+    .ExpiresInSeconds(15)
+    .OnClick(() => Log("clicked"))
+    .OnClose(() => Log("closed"))
+    .WithLeftButton("Install", () => Install())
+    .WithRightButton("Later", () => { })
+    .WithTrimming(NotificationTextTrimType.Trim, 3)
+    .Build());
+```
+
+### Parameter mapping
+
+| Legacy parameter | Builder method |
+|------------------|----------------|
+| `title` | `Create(title, message)` or `WithTitle(title)` |
+| `message` | `WithMessage(message)` |
+| `type` | `OfType(type)` / `AsSuccess()` / `AsWarning()` / `AsError()` / `AsInformation()` |
+| `areaName` | `InArea(areaName)` |
+| `expirationTime` | `ExpiresIn(time)` / `ExpiresInSeconds(n)` / `NeverExpires()` |
+| `onClick` | `OnClick(action)` |
+| `onClose` | `OnClose(action)` |
+| `LeftButton` + `LeftButtonText` | `WithLeftButton(text, action)` |
+| `RightButton` + `RightButtonText` | `WithRightButton(text, action)` |
+| `trim` + `RowsCountWhenTrim` | `WithTrimming(trimType, rows)` |
+| `CloseOnClick` | `CloseOnClick(bool)` |
+| `TitleSettings` | `WithTitleSettings(s => ...)` |
+| `MessageSettings` | `WithMessageSettings(s => ...)` |
+| `ShowXbtn` (`false`) | `HideCloseButton()` |
+| `icon` | `WithIcon(icon)` |
+
+### Custom content — `Show(object content, ...)` → `WithContent(...)`
+
+The `Show(object content, ...)` overload (arbitrary WPF controls) maps to `WithContent`:
+
+```csharp
+// Before
+manager.Show(myCustomGrid, "MainArea", TimeSpan.MaxValue);
+
+// After
+manager.Show(NotificationBuilder
+    .Create()
+    .WithContent(myCustomGrid)
+    .InArea("MainArea")
+    .NeverExpires()
+    .Build());
+```
+
+### WPF-typed values (`Brush`, `ImageSource`)
+
+The Builder uses platform-agnostic types (`NotificationColor`, `NotificationTextSettings`).
+To pass native WPF objects directly, use the WPF builder extensions from `Notification.Wpf.Builder`:
+
+```csharp
+manager.Show(NotificationBuilder
+    .Create("Title", "Message")
+    .WithBackground(Brushes.SteelBlue)                 // WpfBuilderExtensions
+    .WithForeground(Brushes.White)                     // WpfBuilderExtensions
+    .WithImage(myImageSource, ImagePosition.Top)        // WpfBuilderExtensions
+    .Build());
+```
+
+📄 **Source:** [`NotificationBuilder.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Core/Builder/NotificationBuilder.cs) · [`IMessageManager.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Wpf/Base/Interfaces/Base/IMessageManager.cs)
+📂 **Working example:** [`MainWindow.BuilderExamples.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs)
+
+---
+
+## Working examples in the repository
+
+| Topic | File |
+|-------|------|
+| Builder API & migration examples | [`Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs) |
+| Progress bar & `Report(...)` overloads | [`Samples/Notification.Wpf.Sample/MainWindow.xaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs) |
+| Cross-platform progress (Avalonia) | [`Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs`](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs) |
+
+See also: [Builder API reference](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Documentation.md) · [Updates / changelog](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Updates.md)

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 Cross-platform toast notifications library for .NET. Messages, progress bars, Builder API, DI support, lifecycle events.
 
-| [API Docs](https://platonenkov.github.io/Notification.Wpf/) | [Docs](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Documentation.md) | [Updates](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Updates.md) | [WPF Sample](https://github.com/Platonenkov/Notification.Wpf/tree/dev/Samples/Notification.Wpf.Sample) |
-| --- | --- | --- | --- |
+| [API Docs](https://platonenkov.github.io/Notification.Wpf/) | [Docs](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Documentation.md) | [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md) | [Updates](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Updates.md) | [WPF Sample](https://github.com/Platonenkov/Notification.Wpf/tree/dev/Samples/Notification.Wpf.Sample) |
+| --- | --- | --- | --- | --- |
 
 ## Packages
 
@@ -42,6 +42,25 @@ service.Show(NotificationBuilder
     .OnClick(() => Console.WriteLine("Clicked"))
     .Build());
 ```
+
+## Migrating from an earlier version?
+
+Version 10.0 is **fully backward compatible** — existing code keeps working. Two legacy APIs are now
+marked `[Obsolete]` and have clearer replacements:
+
+```csharp
+// Progress: tuple API  ->  Report(...) overloads
+progress.Report(50, "half done", "Working");
+
+// ShowProgressBar: 16 positional parameters  ->  ProgressBarOptions
+manager.ShowProgressBar(new ProgressBarOptions { Title = "Working...", ProgressColor = NotificationColor.LimeGreen });
+
+// Show: up to 18 positional parameters  ->  NotificationBuilder (recommended, the old overloads still work)
+manager.Show(NotificationBuilder.Create("Title", "Message").AsSuccess().ExpiresInSeconds(5).Build());
+```
+
+➡️ **Full step-by-step guide with before/after examples and parameter mapping tables:
+[Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md)**
 
 ## DI Registration
 
@@ -89,13 +108,16 @@ notificationManager.Show("Title", "Message", NotificationType.Success);
 notificationManager.Show("Title", "Message", NotificationType.Warning, "WindowArea");
 
 // Progress bar
-using var progress = notificationManager.ShowProgressBar("Processing...");
+using var progress = notificationManager.ShowProgressBar(new ProgressBarOptions { Title = "Processing..." });
 for (var i = 0; i <= 100; i++)
 {
-    progress.Report(new NotificationProgressReport(i, $"Step {i}", null, true));
+    progress.Report(i, $"Step {i}");   // tuple-free Report overload
     await Task.Delay(30, progress.Cancel);
 }
 ```
+
+> See the [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md) if you
+> still use the 16-parameter `ShowProgressBar(...)` or the tuple-based progress API.
 
 ### Notification Types
 ```

--- a/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
+++ b/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
@@ -320,11 +320,11 @@ namespace Notification.Avalonia.Sample
                 for (int i = 0; i <= 100; i += 2)
                 {
                     progress.CancellationToken.ThrowIfCancellationRequested();
-                    progress.Report(new NotificationProgressReport(i, $"File {i / 2} of 50", null, true));
+                    progress.Report(i, $"File {i / 2} of 50", null, true);
                     await Task.Delay(80);
                 }
 
-                progress.Report(new NotificationProgressReport(100, "Download complete!", "Done", false));
+                progress.Report(100, "Download complete!", "Done", false);
                 await Task.Delay(1000);
             }
             catch (OperationCanceledException)
@@ -354,11 +354,11 @@ namespace Notification.Avalonia.Sample
                 for (int i = 0; i <= 100; i++)
                 {
                     progress.CancellationToken.ThrowIfCancellationRequested();
-                    progress.Report(new NotificationProgressReport(i, $"Step {i} of 100", null, null));
+                    progress.Report(i, $"Step {i} of 100");
                     await Task.Delay(50);
                 }
 
-                progress.Report(new NotificationProgressReport(100, "Complete!", title, false));
+                progress.Report(100, "Complete!", title, false);
                 await Task.Delay(1500);
             }
             catch (OperationCanceledException)

--- a/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs
+++ b/Samples/Notification.Wpf.Sample/MainWindow.BuilderExamples.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Threading.Tasks;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Media;
 using Notification.Core;
 
@@ -56,6 +58,57 @@ namespace Notification.Wpf.Sample
                 .WithPriority(NotificationPriority.Critical)
                 .ExpiresInSeconds(10)
                 .OnClick(() => MessageBox.Show("Clicked!"))
+                .Build());
+        }
+
+        // Migration example: ShowProgressBar(ProgressBarOptions) replaces the obsolete
+        // 16-parameter positional ShowProgressBar overload. See Migration.md, section 2.
+        private async void ShowProgressBarOptionsExample(object sender, RoutedEventArgs e)
+        {
+            INotificationManager notifier = new NotificationManager();
+
+            // Only the properties that differ from the defaults need to be set.
+            using var progress = notifier.ShowProgressBar(new ProgressBarOptions
+            {
+                Title              = "Processing files",
+                ShowCancelButton   = true,
+                BaseWaitingMessage = "Calculation time",
+                ProgressColor      = NotificationColor.LimeGreen,
+            });
+
+            for (int i = 0; i <= 100; i++)
+            {
+                progress.Cancel.ThrowIfCancellationRequested();
+                // Tuple-free Report overload: value + message.
+                progress.Report(i, $"File {i} of 100");
+                await Task.Delay(20, progress.Cancel);
+            }
+        }
+
+        // Migration example: NotificationBuilder.WithContent replaces the
+        // Show(object content, ...) overload for arbitrary custom UI. See Migration.md, section 3.
+        private void ShowBuilderCustomContentExample(object sender, RoutedEventArgs e)
+        {
+            INotificationManager notifier = new NotificationManager();
+
+            StackPanel customContent = new StackPanel { Margin = new Thickness(12) };
+            customContent.Children.Add(new TextBlock
+            {
+                Text = "Custom content via WithContent()",
+                FontWeight = FontWeights.Bold,
+                Foreground = Brushes.White,
+            });
+            customContent.Children.Add(new ProgressBar
+            {
+                Height = 6,
+                Margin = new Thickness(0, 8, 0, 0),
+                IsIndeterminate = true,
+            });
+
+            notifier.Show(NotificationBuilder
+                .Create()
+                .WithContent(customContent)
+                .ExpiresInSeconds(6)
                 .Build());
         }
     }

--- a/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs
+++ b/Samples/Notification.Wpf.Sample/MainWindow.xaml.cs
@@ -648,7 +648,7 @@ namespace Notification.Wpf.Sample
                         for (var i = 0; i <= 100; i++)
                         {
                             progress.Cancel.ThrowIfCancellationRequested();
-                            progress.Report(new NotificationProgressReport(i, message, null, null));
+                            progress.Report(i, message);
                             progress.WaitingTimer.BaseWaitingMessage = i is > 30 and < 70 ? null : "Calculation time";
 
                             await Task.Delay(TimeSpan.FromSeconds(0.03), progress.Cancel);
@@ -658,21 +658,21 @@ namespace Notification.Wpf.Sample
                 for (var i = 0; i <= 100; i++)
                 {
                     progress.Cancel.ThrowIfCancellationRequested();
-                    progress.Report(new NotificationProgressReport(i, $"Progress {i}", "With progress", true));
+                    progress.Report(i, $"Progress {i}", "With progress", true);
                     await Task.Delay(TimeSpan.FromSeconds(0.02), progress.Cancel).ConfigureAwait(false);
                 }
 
                 for (var i = 0; i <= 100; i++)
                 {
                     progress.Cancel.ThrowIfCancellationRequested();
-                    progress.Report(new NotificationProgressReport(null, $"{i}", "Whithout progress", null));
+                    progress.ReportIndeterminate($"{i}", "Whithout progress");
                     await Task.Delay(TimeSpan.FromSeconds(0.03), progress.Cancel).ConfigureAwait(false);
                 }
 
                 for (var i = 0; i <= 100; i++)
                 {
                     progress.Cancel.ThrowIfCancellationRequested();
-                    progress.Report(new NotificationProgressReport(i, null, "Agane whith progress", null));
+                    progress.Report(i, null, "Agane whith progress");
                     await Task.Delay(TimeSpan.FromSeconds(0.02), progress.Cancel).ConfigureAwait(false);
                 }
 
@@ -730,29 +730,8 @@ namespace Notification.Wpf.Sample
                     for (var i = 0; i <= 100; i++)
                     {
                         cancel.ThrowIfCancellationRequested();
-                        progress.Report(new NotificationProgressReport(i, $"Процесс {i}", null, null));
-                        await Task.Delay(TimeSpan.FromSeconds(0.03), cancel);
-                    }
-                }, cancel);
-        public Task CalcAsync(IProgress<(double, string, string)> progress, CancellationToken cancel) =>
-            Task.Run(
-                async () =>
-                {
-                    for (var i = 0; i <= 100; i++)
-                    {
-                        cancel.ThrowIfCancellationRequested();
-                        progress.Report((i, $"Процесс {i}", "Title"));
-                        await Task.Delay(TimeSpan.FromSeconds(0.03), cancel);
-                    }
-                }, cancel);
-        public Task CalcAsync(IProgress<(double, string)> progress, CancellationToken cancel) =>
-            Task.Run(
-                async () =>
-                {
-                    for (var i = 0; i <= 100; i++)
-                    {
-                        cancel.ThrowIfCancellationRequested();
-                        progress.Report((i, $"Процесс {i}"));
+                        // New tuple-free API: value + message (+ optional title) reported directly.
+                        progress.Report(i, $"Процесс {i}", "Title");
                         await Task.Delay(TimeSpan.FromSeconds(0.03), cancel);
                     }
                 }, cancel);

--- a/Samples/Notification.Wpf.Sample/Notification.Wpf.Sample.csproj
+++ b/Samples/Notification.Wpf.Sample/Notification.Wpf.Sample.csproj
@@ -16,8 +16,6 @@
     <PackageReference Include="MathCore.WPF" Version="0.0.50" />
     <PackageReference Include="log4net" Version="3.3.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.142" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.8" />
-    <PackageReference Include="System.Runtime" Version="4.3.1" />
     <PackageReference Include="System.ValueTuple" Version="4.6.2" />
     <PackageReference Include="WPF.ColorPicker" Version="5.0.0.1" />
   </ItemGroup>

--- a/Updates.md
+++ b/Updates.md
@@ -8,6 +8,13 @@
 * **ProgressBar:** added `ShowProgressBar(ProgressBarOptions)` — replaces the 16-parameter positional overload (now `[Obsolete]`)
 * **Builder:** added `NotificationBuilder.WithContent(object)` and `NotificationRequest.Content` — custom content via the Builder API
 * **Docs:** added [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md); full XML documentation across Core, Console, Avalonia, MAUI and WPF
+* **Fix #48:** `Dismiss(Guid)` / `DismissAll()` now actually close the target notification (a real dismiss handle is registered per notification)
+* **Fix #66:** fixed `InvalidOperationException` race — the overlay window reference is dropped on `Closing` and `Show()` is guarded against a closing window
+* **#71:** `NotificationConstants.KeepNotificationVisibleOnMouseOver` — pauses the auto-close timer while the cursor is over the notification
+* **#52:** `Notification.CornerRadius` dependency property and `NotificationConstants.NotificationCornerRadius` — rounded notification cards
+* **#53:** the close (X) icon now follows the notification `Foreground` and can be styled
+* **#65:** `NotificationConstants.OverlayWindowTopmost` — controls whether the overlay window stays on top
+* **#54:** right-click support — `NotificationContent.RightClickAction`, `NotificationRequest.OnRightClick`, `NotificationBuilder.OnRightClick`
 * All packages aligned to version `10.0.0.0`
 * Full backward compatibility — all existing APIs keep working
 

--- a/Updates.md
+++ b/Updates.md
@@ -1,5 +1,16 @@
 ### Update list
 
+`v10.0.0`
+* **Progress API:** added tuple-free `Report(value)`, `Report(value, message)`, `Report(value, message, title)` and `ReportIndeterminate(...)` overloads
+* **Progress API:** added `NotificationProgressReport.Indeterminate(...)` factory and `WithValue`/`WithMessage`/`WithTitle`/`WithShowCancel` helpers
+* **Progress API:** added tuple-free `GetSlowedProgress(int)`, `GetValueProgress(...)`, `GetSlowedValueProgress(...)`
+* **Obsolete:** tuple-based `GetProgress<T>` / `GetSlowedProgress<T>` marked `[Obsolete]` (still functional)
+* **ProgressBar:** added `ShowProgressBar(ProgressBarOptions)` — replaces the 16-parameter positional overload (now `[Obsolete]`)
+* **Builder:** added `NotificationBuilder.WithContent(object)` and `NotificationRequest.Content` — custom content via the Builder API
+* **Docs:** added [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md); full XML documentation across Core, Console, Avalonia, MAUI and WPF
+* All packages aligned to version `10.0.0.0`
+* Full backward compatibility — all existing APIs keep working
+
 `v9.0.0`
 * **Breaking:** Extracted platform-agnostic `Notification.Core` (netstandard2.0) from monolithic WPF project
 * **New platforms:** Added `Notification.Console`, `Notification.Avalonia` (net8.0), `Notification.Maui` (net10.0)
@@ -65,7 +76,7 @@
 * New progress bar initializing template
 * Add more sample in test project
 
-[Constants](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Notification.Wpf/Constants/NotificationConstants.cs)
+[Constants](https://github.com/Platonenkov/Notification.Wpf/blob/dev/src/Notification.Wpf/Constants/NotificationConstants.cs)
 
 Just change it befor first using
 

--- a/src/Notification.Avalonia/AvaloniaNotificationManager.cs
+++ b/src/Notification.Avalonia/AvaloniaNotificationManager.cs
@@ -28,10 +28,19 @@ namespace Notification.Avalonia
         private NotificationOverlayWindow _overlayWindow;
         private bool _useOverlayWindow;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvaloniaNotificationManager"/> class.
+        /// </summary>
         public AvaloniaNotificationManager()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvaloniaNotificationManager"/> class
+        /// with the specified configuration and event service.
+        /// </summary>
+        /// <param name="config">The notification configuration.</param>
+        /// <param name="events">The event service used to raise lifecycle events.</param>
         public AvaloniaNotificationManager(INotificationConfiguration config, INotificationEventService events)
         {
             _config = config;

--- a/src/Notification.Avalonia/Controls/AvaloniaNotificationHost.cs
+++ b/src/Notification.Avalonia/Controls/AvaloniaNotificationHost.cs
@@ -35,6 +35,10 @@ namespace Notification.Avalonia.Controls
         private int _maxItems = 5;
         private NotificationPosition _position = NotificationPosition.BottomRight;
 
+        /// <summary>
+        /// Gets or sets the maximum number of notification cards displayed simultaneously.
+        /// The value is clamped to a minimum of 1.
+        /// </summary>
         public int MaxItems
         {
             get => _maxItems;
@@ -55,6 +59,11 @@ namespace Notification.Avalonia.Controls
             }
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvaloniaNotificationHost"/> class
+        /// attached to the specified top-level window.
+        /// </summary>
+        /// <param name="host">The top-level window the notification overlay is injected into.</param>
         public AvaloniaNotificationHost(TopLevel host)
         {
             _host = host ?? throw new ArgumentNullException(nameof(host));
@@ -766,6 +775,9 @@ namespace Notification.Avalonia.Controls
     /// </summary>
     public sealed class ProgressCardHandle
     {
+        /// <summary>
+        /// Gets the unique identifier of the progress notification.
+        /// </summary>
         public Guid Id { get; }
 
         private TextBlock _titleBlock;
@@ -778,9 +790,20 @@ namespace Notification.Avalonia.Controls
 
         internal event Action CloseRequested;
 
+        /// <summary>
+        /// Gets the cancellation token signaled when the user cancels the progress operation.
+        /// </summary>
         public CancellationToken CancellationToken => _cancelSource.Token;
+
+        /// <summary>
+        /// Gets the cancellation token source backing the progress operation.
+        /// </summary>
         public CancellationTokenSource CancelSource => _cancelSource;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressCardHandle"/> class.
+        /// </summary>
+        /// <param name="id">The unique identifier of the progress notification.</param>
         public ProgressCardHandle(Guid id)
         {
             Id = id;

--- a/src/Notification.Avalonia/Notification.Avalonia.xml
+++ b/src/Notification.Avalonia/Notification.Avalonia.xml
@@ -10,6 +10,19 @@
             Supports two display modes: in-window overlay and separate topmost overlay window.
             </summary>
         </member>
+        <member name="M:Notification.Avalonia.AvaloniaNotificationManager.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Avalonia.AvaloniaNotificationManager"/> class.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.AvaloniaNotificationManager.#ctor(Notification.Core.INotificationConfiguration,Notification.Core.INotificationEventService)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Avalonia.AvaloniaNotificationManager"/> class
+            with the specified configuration and event service.
+            </summary>
+            <param name="config">The notification configuration.</param>
+            <param name="events">The event service used to raise lifecycle events.</param>
+        </member>
         <member name="M:Notification.Avalonia.AvaloniaNotificationManager.SetHost(Avalonia.Controls.TopLevel)">
             <summary>
             Attach the notification manager to a TopLevel (Window or similar).
@@ -74,11 +87,24 @@
             Injects into the Window content as a Grid overlay.
             </summary>
         </member>
+        <member name="P:Notification.Avalonia.Controls.AvaloniaNotificationHost.MaxItems">
+            <summary>
+            Gets or sets the maximum number of notification cards displayed simultaneously.
+            The value is clamped to a minimum of 1.
+            </summary>
+        </member>
         <member name="P:Notification.Avalonia.Controls.AvaloniaNotificationHost.Position">
             <summary>
             Gets or sets the position where notifications appear.
             Can be changed at runtime — takes effect immediately.
             </summary>
+        </member>
+        <member name="M:Notification.Avalonia.Controls.AvaloniaNotificationHost.#ctor(Avalonia.Controls.TopLevel)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Avalonia.Controls.AvaloniaNotificationHost"/> class
+            attached to the specified top-level window.
+            </summary>
+            <param name="host">The top-level window the notification overlay is injected into.</param>
         </member>
         <member name="M:Notification.Avalonia.Controls.AvaloniaNotificationHost.AddCardToPanel(Avalonia.Controls.Border)">
             <summary>
@@ -121,6 +147,27 @@
             <summary>
             Handle for updating a progress notification card from background threads.
             </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Controls.ProgressCardHandle.Id">
+            <summary>
+            Gets the unique identifier of the progress notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Controls.ProgressCardHandle.CancellationToken">
+            <summary>
+            Gets the cancellation token signaled when the user cancels the progress operation.
+            </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Controls.ProgressCardHandle.CancelSource">
+            <summary>
+            Gets the cancellation token source backing the progress operation.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.Controls.ProgressCardHandle.#ctor(System.Guid)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Avalonia.Controls.ProgressCardHandle"/> class.
+            </summary>
+            <param name="id">The unique identifier of the progress notification.</param>
         </member>
         <member name="M:Notification.Avalonia.Controls.ProgressCardHandle.UpdateProgress(System.Nullable{System.Double},System.String,System.String,System.Nullable{System.Boolean})">
             <summary>
@@ -167,6 +214,56 @@
             Avalonia implementation of INotifierProgress.
             Updates the progress notification card and closes it on Dispose.
             </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Progress.AvaloniaNotifierProgress.IsFinished">
+            <summary>
+            Gets a value indicating whether the progress operation has finished.
+            </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Progress.AvaloniaNotifierProgress.CancellationToken">
+            <summary>
+            Gets the cancellation token signaled when the user cancels the progress operation.
+            </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Progress.AvaloniaNotifierProgress.CancelSource">
+            <summary>
+            Gets the cancellation token source backing the progress operation.
+            </summary>
+        </member>
+        <member name="P:Notification.Avalonia.Progress.AvaloniaNotifierProgress.WaitingTimer">
+            <summary>
+            Gets the timer that tracks elapsed time and computes the estimated remaining time.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.Progress.AvaloniaNotifierProgress.#ctor(Notification.Avalonia.Controls.ProgressCardHandle)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Avalonia.Progress.AvaloniaNotifierProgress"/> class.
+            </summary>
+            <param name="handle">The handle used to update the progress notification card.</param>
+        </member>
+        <member name="M:Notification.Avalonia.Progress.AvaloniaNotifierProgress.Report(Notification.Core.NotificationProgressReport)">
+            <summary>
+            Reports a progress update to the notification card.
+            </summary>
+            <param name="value">The progress report containing value, message, title, and cancel visibility.</param>
+        </member>
+        <member name="M:Notification.Avalonia.Progress.AvaloniaNotifierProgress.Dispose">
+            <summary>
+            Marks the progress operation as finished and closes the notification card.
+            </summary>
+        </member>
+        <member name="T:Notification.Avalonia.AvaloniaNotificationServiceCollectionExtensions">
+            <summary>
+            Provides extension methods for registering Avalonia notification services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.AvaloniaNotificationServiceCollectionExtensions.AddAvaloniaNotifications(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the Avalonia notification manager and core notification services.
+            </summary>
+            <param name="services">The service collection to add the services to.</param>
+            <param name="configure">An optional delegate to configure the notification settings.</param>
+            <returns>The same service collection instance for chaining.</returns>
         </member>
     </members>
 </doc>

--- a/src/Notification.Avalonia/Progress/AvaloniaNotifierProgress.cs
+++ b/src/Notification.Avalonia/Progress/AvaloniaNotifierProgress.cs
@@ -19,11 +19,30 @@ namespace Notification.Avalonia.Progress
 
         private bool _isFinished;
 
+        /// <summary>
+        /// Gets a value indicating whether the progress operation has finished.
+        /// </summary>
         public bool IsFinished => _isFinished;
+
+        /// <summary>
+        /// Gets the cancellation token signaled when the user cancels the progress operation.
+        /// </summary>
         public CancellationToken CancellationToken => _handle.CancellationToken;
+
+        /// <summary>
+        /// Gets the cancellation token source backing the progress operation.
+        /// </summary>
         public CancellationTokenSource CancelSource => _handle.CancelSource;
+
+        /// <summary>
+        /// Gets the timer that tracks elapsed time and computes the estimated remaining time.
+        /// </summary>
         public OperationTimer WaitingTimer => _waitingTimer;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="AvaloniaNotifierProgress"/> class.
+        /// </summary>
+        /// <param name="handle">The handle used to update the progress notification card.</param>
         public AvaloniaNotifierProgress(ProgressCardHandle handle)
         {
             _handle = handle ?? throw new ArgumentNullException(nameof(handle));
@@ -31,6 +50,10 @@ namespace Notification.Avalonia.Progress
             _waitingTimer.Start();
         }
 
+        /// <summary>
+        /// Reports a progress update to the notification card.
+        /// </summary>
+        /// <param name="value">The progress report containing value, message, title, and cancel visibility.</param>
         public void Report(NotificationProgressReport value)
         {
             if (_isFinished)
@@ -57,6 +80,9 @@ namespace Notification.Avalonia.Progress
             }
         }
 
+        /// <summary>
+        /// Marks the progress operation as finished and closes the notification card.
+        /// </summary>
         public void Dispose()
         {
             _isFinished = true;

--- a/src/Notification.Avalonia/ServiceCollectionExtensions.cs
+++ b/src/Notification.Avalonia/ServiceCollectionExtensions.cs
@@ -5,8 +5,17 @@ using Notification.Core;
 
 namespace Notification.Avalonia
 {
+    /// <summary>
+    /// Provides extension methods for registering Avalonia notification services in an <see cref="IServiceCollection"/>.
+    /// </summary>
     public static class AvaloniaNotificationServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the Avalonia notification manager and core notification services.
+        /// </summary>
+        /// <param name="services">The service collection to add the services to.</param>
+        /// <param name="configure">An optional delegate to configure the notification settings.</param>
+        /// <returns>The same service collection instance for chaining.</returns>
         public static IServiceCollection AddAvaloniaNotifications(
             this IServiceCollection services,
             Action<INotificationConfiguration> configure = null)

--- a/src/Notification.Console/ConsoleNotificationManager.cs
+++ b/src/Notification.Console/ConsoleNotificationManager.cs
@@ -4,6 +4,9 @@ using Notification.Core;
 
 namespace Notification.Console
 {
+    /// <summary>
+    /// Renders notifications to the system console with colored output and progress bars.
+    /// </summary>
     public class ConsoleNotificationManager : INotificationService
     {
         private readonly INotificationConfiguration _config;
@@ -11,16 +14,30 @@ namespace Notification.Console
         private readonly ConcurrentDictionary<Guid, bool> _activeNotifications = new ConcurrentDictionary<Guid, bool>();
         private readonly object _consoleLock = new object();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsoleNotificationManager"/> class.
+        /// </summary>
         public ConsoleNotificationManager()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ConsoleNotificationManager"/> class
+        /// with the specified configuration and event service.
+        /// </summary>
+        /// <param name="config">The notification configuration.</param>
+        /// <param name="events">The event service used to raise lifecycle events.</param>
         public ConsoleNotificationManager(INotificationConfiguration config, INotificationEventService events)
         {
             _config = config;
             _events = events;
         }
 
+        /// <summary>
+        /// Displays the specified notification in the console.
+        /// </summary>
+        /// <param name="request">The notification request to display.</param>
+        /// <returns>The unique identifier of the displayed notification.</returns>
         public Guid Show(NotificationRequest request)
         {
             Guid id = request.Id;
@@ -68,6 +85,10 @@ namespace Notification.Console
             return id;
         }
 
+        /// <summary>
+        /// Dismisses the notification with the specified identifier.
+        /// </summary>
+        /// <param name="notificationId">The identifier of the notification to dismiss.</param>
         public void Dismiss(Guid notificationId)
         {
             bool removed;
@@ -76,6 +97,9 @@ namespace Notification.Console
                 notificationId, NotificationLifecycleStage.Dismissed, null, null));
         }
 
+        /// <summary>
+        /// Dismisses all currently active notifications.
+        /// </summary>
         public void DismissAll()
         {
             foreach (System.Collections.Generic.KeyValuePair<Guid, bool> kvp in _activeNotifications.ToArray())
@@ -84,6 +108,11 @@ namespace Notification.Console
             }
         }
 
+        /// <summary>
+        /// Renders an inline progress bar in the console.
+        /// </summary>
+        /// <param name="title">The text displayed next to the progress bar.</param>
+        /// <param name="percent">The completion percentage in the range 0 to 100.</param>
         public void ShowProgress(string title, double percent)
         {
             lock (_consoleLock)

--- a/src/Notification.Console/Notification.Console.xml
+++ b/src/Notification.Console/Notification.Console.xml
@@ -4,5 +4,61 @@
         <name>Notification.Console</name>
     </assembly>
     <members>
+        <member name="T:Notification.Console.ConsoleNotificationManager">
+            <summary>
+            Renders notifications to the system console with colored output and progress bars.
+            </summary>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Console.ConsoleNotificationManager"/> class.
+            </summary>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.#ctor(Notification.Core.INotificationConfiguration,Notification.Core.INotificationEventService)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Console.ConsoleNotificationManager"/> class
+            with the specified configuration and event service.
+            </summary>
+            <param name="config">The notification configuration.</param>
+            <param name="events">The event service used to raise lifecycle events.</param>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.Show(Notification.Core.NotificationRequest)">
+            <summary>
+            Displays the specified notification in the console.
+            </summary>
+            <param name="request">The notification request to display.</param>
+            <returns>The unique identifier of the displayed notification.</returns>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.Dismiss(System.Guid)">
+            <summary>
+            Dismisses the notification with the specified identifier.
+            </summary>
+            <param name="notificationId">The identifier of the notification to dismiss.</param>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.DismissAll">
+            <summary>
+            Dismisses all currently active notifications.
+            </summary>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationManager.ShowProgress(System.String,System.Double)">
+            <summary>
+            Renders an inline progress bar in the console.
+            </summary>
+            <param name="title">The text displayed next to the progress bar.</param>
+            <param name="percent">The completion percentage in the range 0 to 100.</param>
+        </member>
+        <member name="T:Notification.Console.ConsoleNotificationServiceCollectionExtensions">
+            <summary>
+            Provides extension methods for registering console notification services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+        </member>
+        <member name="M:Notification.Console.ConsoleNotificationServiceCollectionExtensions.AddConsoleNotifications(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the console notification manager and core notification services.
+            </summary>
+            <param name="services">The service collection to add the services to.</param>
+            <param name="configure">An optional delegate to configure the notification settings.</param>
+            <returns>The same service collection instance for chaining.</returns>
+        </member>
     </members>
 </doc>

--- a/src/Notification.Console/ServiceCollectionExtensions.cs
+++ b/src/Notification.Console/ServiceCollectionExtensions.cs
@@ -5,8 +5,17 @@ using Notification.Core;
 
 namespace Notification.Console
 {
+    /// <summary>
+    /// Provides extension methods for registering console notification services in an <see cref="IServiceCollection"/>.
+    /// </summary>
     public static class ConsoleNotificationServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the console notification manager and core notification services.
+        /// </summary>
+        /// <param name="services">The service collection to add the services to.</param>
+        /// <param name="configure">An optional delegate to configure the notification settings.</param>
+        /// <returns>The same service collection instance for chaining.</returns>
         public static IServiceCollection AddConsoleNotifications(
             this IServiceCollection services,
             Action<INotificationConfiguration> configure = null)

--- a/src/Notification.Core/Abstractions/AbsolutePositionData.cs
+++ b/src/Notification.Core/Abstractions/AbsolutePositionData.cs
@@ -1,9 +1,17 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents absolute position data for placing a notification at specific screen coordinates relative to a corner.
+    /// </summary>
     public class AbsolutePositionData
     {
+        /// <summary>Gets or sets the horizontal offset in pixels from the base corner.</summary>
         public double X { get; set; }
+
+        /// <summary>Gets or sets the vertical offset in pixels from the base corner.</summary>
         public double Y { get; set; }
+
+        /// <summary>Gets or sets the screen corner used as the origin for positioning.</summary>
         public Corner BaseCorner { get; set; }
     }
 }

--- a/src/Notification.Core/Abstractions/NotificationColor.cs
+++ b/src/Notification.Core/Abstractions/NotificationColor.cs
@@ -3,13 +3,30 @@ using System.Globalization;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents a platform-independent RGBA color for notification styling.
+    /// </summary>
     public readonly struct NotificationColor : IEquatable<NotificationColor>
     {
+        /// <summary>Gets the red component of the color (0–255).</summary>
         public byte R { get; }
+
+        /// <summary>Gets the green component of the color (0–255).</summary>
         public byte G { get; }
+
+        /// <summary>Gets the blue component of the color (0–255).</summary>
         public byte B { get; }
+
+        /// <summary>Gets the alpha (opacity) component of the color (0–255).</summary>
         public byte A { get; }
 
+        /// <summary>
+        /// Initializes a new <see cref="NotificationColor"/> with the specified RGBA components.
+        /// </summary>
+        /// <param name="r">The red component (0–255).</param>
+        /// <param name="g">The green component (0–255).</param>
+        /// <param name="b">The blue component (0–255).</param>
+        /// <param name="a">The alpha component (0–255). Defaults to 255 (fully opaque).</param>
         public NotificationColor(byte r, byte g, byte b, byte a = 255)
         {
             R = r;
@@ -18,10 +35,32 @@ namespace Notification.Core
             A = a;
         }
 
+        /// <summary>
+        /// Creates a fully opaque color from the specified RGB components.
+        /// </summary>
+        /// <param name="r">The red component (0–255).</param>
+        /// <param name="g">The green component (0–255).</param>
+        /// <param name="b">The blue component (0–255).</param>
+        /// <returns>A new <see cref="NotificationColor"/> with alpha set to 255.</returns>
         public static NotificationColor FromRgb(byte r, byte g, byte b) => new NotificationColor(r, g, b);
 
+        /// <summary>
+        /// Creates a color from the specified ARGB components.
+        /// </summary>
+        /// <param name="a">The alpha component (0–255).</param>
+        /// <param name="r">The red component (0–255).</param>
+        /// <param name="g">The green component (0–255).</param>
+        /// <param name="b">The blue component (0–255).</param>
+        /// <returns>A new <see cref="NotificationColor"/> instance.</returns>
         public static NotificationColor FromArgb(byte a, byte r, byte g, byte b) => new NotificationColor(r, g, b, a);
 
+        /// <summary>
+        /// Parses a hexadecimal color string in #RRGGBB or #AARRGGBB format.
+        /// </summary>
+        /// <param name="hex">The hex color string, with or without a leading '#'.</param>
+        /// <returns>A new <see cref="NotificationColor"/> parsed from the hex string.</returns>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="hex"/> is null or whitespace.</exception>
+        /// <exception cref="FormatException">Thrown when the hex string is not in a valid format.</exception>
         public static NotificationColor FromHex(string hex)
         {
             if (string.IsNullOrWhiteSpace(hex))
@@ -47,24 +86,58 @@ namespace Notification.Core
             }
         }
 
+        /// <summary>
+        /// Converts this color to its #AARRGGBB hexadecimal string representation.
+        /// </summary>
+        /// <returns>A hex string in the format #AARRGGBB.</returns>
         public string ToHex() => $"#{A:X2}{R:X2}{G:X2}{B:X2}";
 
+        /// <summary>
+        /// Implicitly converts a hex color string to a <see cref="NotificationColor"/>.
+        /// </summary>
+        /// <param name="hex">The hex color string to convert.</param>
         public static implicit operator NotificationColor(string hex) => FromHex(hex);
 
+        /// <summary>Represents the color white (255, 255, 255).</summary>
         public static readonly NotificationColor White = new NotificationColor(255, 255, 255);
+
+        /// <summary>Represents the color white smoke (245, 245, 245).</summary>
         public static readonly NotificationColor WhiteSmoke = new NotificationColor(245, 245, 245);
+
+        /// <summary>Represents the color lime green (50, 205, 50).</summary>
         public static readonly NotificationColor LimeGreen = new NotificationColor(50, 205, 50);
+
+        /// <summary>Represents the color orange (255, 165, 0).</summary>
         public static readonly NotificationColor Orange = new NotificationColor(255, 165, 0);
+
+        /// <summary>Represents the color orange red (255, 69, 0).</summary>
         public static readonly NotificationColor OrangeRed = new NotificationColor(255, 69, 0);
+
+        /// <summary>Represents the color cornflower blue (100, 149, 237).</summary>
         public static readonly NotificationColor CornflowerBlue = new NotificationColor(100, 149, 237);
+
+        /// <summary>Represents the color dark gray (68, 68, 68).</summary>
         public static readonly NotificationColor DarkGray = new NotificationColor(68, 68, 68);
+
+        /// <summary>Represents the color green (1, 211, 40).</summary>
         public static readonly NotificationColor Green = new NotificationColor(1, 211, 40);
 
+        /// <inheritdoc />
         public bool Equals(NotificationColor other) => R == other.R && G == other.G && B == other.B && A == other.A;
+
+        /// <inheritdoc />
         public override bool Equals(object obj) => obj is NotificationColor other && Equals(other);
+
+        /// <inheritdoc />
         public override int GetHashCode() => (R << 24) | (G << 16) | (B << 8) | A;
+
+        /// <summary>Determines whether two <see cref="NotificationColor"/> instances are equal.</summary>
         public static bool operator ==(NotificationColor left, NotificationColor right) => left.Equals(right);
+
+        /// <summary>Determines whether two <see cref="NotificationColor"/> instances are not equal.</summary>
         public static bool operator !=(NotificationColor left, NotificationColor right) => !left.Equals(right);
+
+        /// <inheritdoc />
         public override string ToString() => ToHex();
     }
 }

--- a/src/Notification.Core/Abstractions/NotificationImageData.cs
+++ b/src/Notification.Core/Abstractions/NotificationImageData.cs
@@ -1,9 +1,17 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents image data and layout settings for a notification image.
+    /// </summary>
     public class NotificationImageData
     {
+        /// <summary>Gets or sets the raw image bytes. Used when the image is provided as in-memory data.</summary>
         public byte[] RawData { get; set; }
+
+        /// <summary>Gets or sets the URI of the image resource. Used when the image is loaded from a file or URL.</summary>
         public string Uri { get; set; }
+
+        /// <summary>Gets or sets the position of the image within the notification layout.</summary>
         public ImagePosition Position { get; set; } = ImagePosition.None;
     }
 }

--- a/src/Notification.Core/Abstractions/NotificationTextSettings.cs
+++ b/src/Notification.Core/Abstractions/NotificationTextSettings.cs
@@ -1,14 +1,32 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents text rendering settings for notification content, including font, alignment, and opacity.
+    /// </summary>
     public class NotificationTextSettings
     {
+        /// <summary>Gets or sets the font family name. Defaults to "Segoe UI".</summary>
         public string FontFamily { get; set; } = "Segoe UI";
+
+        /// <summary>Gets or sets the font size in device-independent pixels. Defaults to 14.0.</summary>
         public double FontSize { get; set; } = 14.0;
+
+        /// <summary>Gets or sets the font style (e.g., Normal, Italic). Defaults to <see cref="NotificationFontStyle.Normal"/>.</summary>
         public NotificationFontStyle FontStyle { get; set; } = NotificationFontStyle.Normal;
+
+        /// <summary>Gets or sets the font weight (e.g., Normal, Bold). Defaults to <see cref="NotificationFontWeight.Normal"/>.</summary>
         public NotificationFontWeight FontWeight { get; set; } = NotificationFontWeight.Normal;
+
+        /// <summary>Gets or sets the text alignment within the text block. Defaults to <see cref="NotificationTextAlignment.Left"/>.</summary>
         public NotificationTextAlignment TextAlignment { get; set; } = NotificationTextAlignment.Left;
+
+        /// <summary>Gets or sets the horizontal alignment of the text element. Defaults to <see cref="NotificationHorizontalAlignment.Stretch"/>.</summary>
         public NotificationHorizontalAlignment HorizontalAlignment { get; set; } = NotificationHorizontalAlignment.Stretch;
+
+        /// <summary>Gets or sets the vertical alignment of the text element. Defaults to <see cref="NotificationVerticalAlignment.Stretch"/>.</summary>
         public NotificationVerticalAlignment VerticalAlignment { get; set; } = NotificationVerticalAlignment.Stretch;
+
+        /// <summary>Gets or sets the text opacity, where 0.0 is fully transparent and 1.0 is fully opaque. Defaults to 1.0.</summary>
         public double Opacity { get; set; } = 1.0;
     }
 }

--- a/src/Notification.Core/Abstractions/NotificationThickness.cs
+++ b/src/Notification.Core/Abstractions/NotificationThickness.cs
@@ -2,15 +2,36 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents a platform-independent thickness (margin or padding) with values for each side.
+    /// </summary>
     public readonly struct NotificationThickness : IEquatable<NotificationThickness>
     {
+        /// <summary>Gets the left side thickness in device-independent pixels.</summary>
         public double Left { get; }
+
+        /// <summary>Gets the top side thickness in device-independent pixels.</summary>
         public double Top { get; }
+
+        /// <summary>Gets the right side thickness in device-independent pixels.</summary>
         public double Right { get; }
+
+        /// <summary>Gets the bottom side thickness in device-independent pixels.</summary>
         public double Bottom { get; }
 
+        /// <summary>
+        /// Initializes a new <see cref="NotificationThickness"/> with the same value applied to all four sides.
+        /// </summary>
+        /// <param name="uniform">The uniform thickness value for all sides.</param>
         public NotificationThickness(double uniform) : this(uniform, uniform, uniform, uniform) { }
 
+        /// <summary>
+        /// Initializes a new <see cref="NotificationThickness"/> with individual values for each side.
+        /// </summary>
+        /// <param name="left">The left side thickness.</param>
+        /// <param name="top">The top side thickness.</param>
+        /// <param name="right">The right side thickness.</param>
+        /// <param name="bottom">The bottom side thickness.</param>
         public NotificationThickness(double left, double top, double right, double bottom)
         {
             Left = left;
@@ -19,12 +40,15 @@ namespace Notification.Core
             Bottom = bottom;
         }
 
+        /// <inheritdoc />
         public bool Equals(NotificationThickness other) =>
             Left.Equals(other.Left) && Top.Equals(other.Top) &&
             Right.Equals(other.Right) && Bottom.Equals(other.Bottom);
 
+        /// <inheritdoc />
         public override bool Equals(object obj) => obj is NotificationThickness other && Equals(other);
 
+        /// <inheritdoc />
         public override int GetHashCode()
         {
             unchecked
@@ -38,7 +62,10 @@ namespace Notification.Core
             }
         }
 
+        /// <summary>Determines whether two <see cref="NotificationThickness"/> instances are equal.</summary>
         public static bool operator ==(NotificationThickness left, NotificationThickness right) => left.Equals(right);
+
+        /// <summary>Determines whether two <see cref="NotificationThickness"/> instances are not equal.</summary>
         public static bool operator !=(NotificationThickness left, NotificationThickness right) => !left.Equals(right);
     }
 }

--- a/src/Notification.Core/Builder/NotificationBuilder.cs
+++ b/src/Notification.Core/Builder/NotificationBuilder.cs
@@ -3,62 +3,207 @@ using System.Collections.Generic;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides a fluent API for constructing <see cref="NotificationRequest"/> instances.
+    /// </summary>
     public class NotificationBuilder
     {
+        /// <summary>The notification title.</summary>
         protected string _title;
+        /// <summary>The notification message body.</summary>
         protected string _message;
+        /// <summary>The notification type.</summary>
         protected NotificationType _type = NotificationType.None;
+        /// <summary>The name of the target notification area.</summary>
         protected string _areaName = "";
+        /// <summary>The time after which the notification expires; <c>null</c> means never.</summary>
         protected TimeSpan? _expirationTime;
+        /// <summary>Indicates whether the notification closes when clicked.</summary>
         protected bool _closeOnClick = true;
+        /// <summary>Indicates whether the close button is shown.</summary>
         protected bool _showCloseButton = true;
+        /// <summary>The notification priority.</summary>
         protected NotificationPriority _priority = NotificationPriority.Normal;
+        /// <summary>The grouping key used to coalesce related notifications.</summary>
         protected string _groupKey;
+        /// <summary>The background color override.</summary>
         protected NotificationColor? _backgroundColor;
+        /// <summary>The foreground color override.</summary>
         protected NotificationColor? _foregroundColor;
+        /// <summary>The text settings applied to the title.</summary>
         protected NotificationTextSettings _titleSettings;
+        /// <summary>The text settings applied to the message.</summary>
         protected NotificationTextSettings _messageSettings;
+        /// <summary>The text trimming mode.</summary>
         protected NotificationTextTrimType _trimType = NotificationTextTrimType.NoTrim;
+        /// <summary>The maximum number of message rows before trimming applies.</summary>
         protected uint _rowsCount = 2;
+        /// <summary>The action invoked when the left button is clicked.</summary>
         protected Action _leftButtonAction;
+        /// <summary>The content (text) of the left button.</summary>
         protected string _leftButtonContent;
+        /// <summary>The action invoked when the right button is clicked.</summary>
         protected Action _rightButtonAction;
+        /// <summary>The content (text) of the right button.</summary>
         protected string _rightButtonContent;
+        /// <summary>The action invoked when the notification is clicked.</summary>
         protected Action _onClick;
+        /// <summary>The action invoked when the notification is closed.</summary>
         protected Action _onClose;
+        /// <summary>The notification icon.</summary>
         protected object _icon;
+        /// <summary>The platform-specific image object.</summary>
         protected object _platformImage;
+        /// <summary>The collection of platform-specific extension values.</summary>
         protected Dictionary<string, object> _extensions;
 
+        /// <summary>
+        /// Creates a new empty <see cref="NotificationBuilder"/> instance.
+        /// </summary>
+        /// <returns>A new builder instance.</returns>
         public static NotificationBuilder Create() => new NotificationBuilder();
 
+        /// <summary>
+        /// Creates a new <see cref="NotificationBuilder"/> instance with the specified title and message.
+        /// </summary>
+        /// <param name="title">The notification title.</param>
+        /// <param name="message">The notification message.</param>
+        /// <returns>A new builder instance with title and message set.</returns>
         public static NotificationBuilder Create(string title, string message) =>
             new NotificationBuilder().WithTitle(title).WithMessage(message);
 
+        /// <summary>
+        /// Sets the notification title.
+        /// </summary>
+        /// <param name="title">The title text.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithTitle(string title) { _title = title; return this; }
+
+        /// <summary>
+        /// Sets the notification message.
+        /// </summary>
+        /// <param name="message">The message text.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithMessage(string message) { _message = message; return this; }
+
+        /// <summary>
+        /// Sets the notification type.
+        /// </summary>
+        /// <param name="type">The notification type.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder OfType(NotificationType type) { _type = type; return this; }
 
+        /// <summary>
+        /// Sets the notification type to <see cref="NotificationType.Information"/>.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder AsInformation() => OfType(NotificationType.Information);
+
+        /// <summary>
+        /// Sets the notification type to <see cref="NotificationType.Success"/>.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder AsSuccess() => OfType(NotificationType.Success);
+
+        /// <summary>
+        /// Sets the notification type to <see cref="NotificationType.Warning"/>.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder AsWarning() => OfType(NotificationType.Warning);
+
+        /// <summary>
+        /// Sets the notification type to <see cref="NotificationType.Error"/>.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder AsError() => OfType(NotificationType.Error);
 
+        /// <summary>
+        /// Sets the notification area name where the notification will be displayed.
+        /// </summary>
+        /// <param name="areaName">The target area name.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder InArea(string areaName) { _areaName = areaName; return this; }
+
+        /// <summary>
+        /// Sets the notification expiration time.
+        /// </summary>
+        /// <param name="time">The duration after which the notification automatically closes.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder ExpiresIn(TimeSpan time) { _expirationTime = time; return this; }
+
+        /// <summary>
+        /// Sets the notification expiration time in seconds.
+        /// </summary>
+        /// <param name="seconds">The number of seconds before the notification closes.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder ExpiresInSeconds(double seconds) => ExpiresIn(TimeSpan.FromSeconds(seconds));
+
+        /// <summary>
+        /// Configures the notification to never expire automatically.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder NeverExpires() { _expirationTime = TimeSpan.MaxValue; return this; }
+
+        /// <summary>
+        /// Sets whether the notification closes when clicked.
+        /// </summary>
+        /// <param name="close">True to close on click; false to keep open.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder CloseOnClick(bool close = true) { _closeOnClick = close; return this; }
+
+        /// <summary>
+        /// Hides the close button on the notification.
+        /// </summary>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder HideCloseButton() { _showCloseButton = false; return this; }
 
+        /// <summary>
+        /// Sets the notification display priority.
+        /// </summary>
+        /// <param name="priority">The priority level.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithPriority(NotificationPriority priority) { _priority = priority; return this; }
+
+        /// <summary>
+        /// Sets the group key for notification deduplication.
+        /// </summary>
+        /// <param name="groupKey">The group key. Notifications with the same key replace each other.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder GroupAs(string groupKey) { _groupKey = groupKey; return this; }
 
+        /// <summary>
+        /// Sets the notification background color.
+        /// </summary>
+        /// <param name="color">The background color.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithBackground(NotificationColor color) { _backgroundColor = color; return this; }
+
+        /// <summary>
+        /// Sets the notification background color from a hex string.
+        /// </summary>
+        /// <param name="hex">The hex color string (e.g., "#FF0000").</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithBackground(string hex) { _backgroundColor = NotificationColor.FromHex(hex); return this; }
+
+        /// <summary>
+        /// Sets the notification foreground (text) color.
+        /// </summary>
+        /// <param name="color">The foreground color.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithForeground(NotificationColor color) { _foregroundColor = color; return this; }
+
+        /// <summary>
+        /// Sets the notification foreground (text) color from a hex string.
+        /// </summary>
+        /// <param name="hex">The hex color string (e.g., "#FFFFFF").</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithForeground(string hex) { _foregroundColor = NotificationColor.FromHex(hex); return this; }
 
+        /// <summary>
+        /// Configures the title text rendering settings.
+        /// </summary>
+        /// <param name="configure">An action to configure the title text settings.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithTitleSettings(Action<NotificationTextSettings> configure)
         {
             _titleSettings = _titleSettings ?? new NotificationTextSettings();
@@ -66,6 +211,11 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Configures the message text rendering settings.
+        /// </summary>
+        /// <param name="configure">An action to configure the message text settings.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithMessageSettings(Action<NotificationTextSettings> configure)
         {
             _messageSettings = _messageSettings ?? new NotificationTextSettings();
@@ -73,6 +223,12 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Configures text trimming behavior for the notification message.
+        /// </summary>
+        /// <param name="trimType">The text trimming type.</param>
+        /// <param name="rows">The maximum number of visible rows before trimming.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithTrimming(NotificationTextTrimType trimType, uint rows = 2)
         {
             _trimType = trimType;
@@ -80,6 +236,12 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Configures the left button with text and a click action.
+        /// </summary>
+        /// <param name="text">The button label text.</param>
+        /// <param name="action">The action invoked when the button is clicked.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithLeftButton(string text, Action action)
         {
             _leftButtonContent = text;
@@ -87,6 +249,12 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Configures the right button with text and a click action.
+        /// </summary>
+        /// <param name="text">The button label text.</param>
+        /// <param name="action">The action invoked when the button is clicked.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithRightButton(string text, Action action)
         {
             _rightButtonContent = text;
@@ -94,20 +262,53 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Configures Ok and Cancel buttons with the specified actions.
+        /// </summary>
+        /// <param name="onOk">The action invoked when Ok is clicked.</param>
+        /// <param name="onCancel">The action invoked when Cancel is clicked. If null, a no-op action is used.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithOkCancel(Action onOk, Action onCancel = null) =>
             WithLeftButton("Ok", onOk).WithRightButton("Cancel", onCancel ?? (() => { }));
 
+        /// <summary>
+        /// Sets the action invoked when the notification body is clicked.
+        /// </summary>
+        /// <param name="onClick">The click action.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder OnClick(Action onClick) { _onClick = onClick; return this; }
+
+        /// <summary>
+        /// Sets the action invoked when the notification is closed.
+        /// </summary>
+        /// <param name="onClose">The close action.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder OnClose(Action onClose) { _onClose = onClose; return this; }
 
+        /// <summary>
+        /// Sets the notification icon. The type is platform-dependent.
+        /// </summary>
+        /// <param name="icon">The icon object.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithIcon(object icon) { _icon = icon; return this; }
 
+        /// <summary>
+        /// Sets the notification image.
+        /// </summary>
+        /// <param name="image">The image data to display in the notification.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithImage(NotificationImageData image)
         {
             _platformImage = image;
             return this;
         }
 
+        /// <summary>
+        /// Adds a custom extension key-value pair to the notification.
+        /// </summary>
+        /// <param name="key">The extension key.</param>
+        /// <param name="value">The extension value.</param>
+        /// <returns>The current builder instance for chaining.</returns>
         public NotificationBuilder WithExtension(string key, object value)
         {
             _extensions = _extensions ?? new Dictionary<string, object>();
@@ -115,6 +316,10 @@ namespace Notification.Core
             return this;
         }
 
+        /// <summary>
+        /// Builds and returns the configured <see cref="NotificationRequest"/> instance.
+        /// </summary>
+        /// <returns>A new <see cref="NotificationRequest"/> populated with the builder's settings.</returns>
         public NotificationRequest Build() => new NotificationRequest
         {
             Title = _title,

--- a/src/Notification.Core/Builder/NotificationBuilder.cs
+++ b/src/Notification.Core/Builder/NotificationBuilder.cs
@@ -54,6 +54,8 @@ namespace Notification.Core
         protected object _icon;
         /// <summary>The platform-specific image object.</summary>
         protected object _platformImage;
+        /// <summary>The arbitrary platform-specific content object.</summary>
+        protected object _content;
         /// <summary>The collection of platform-specific extension values.</summary>
         protected Dictionary<string, object> _extensions;
 
@@ -304,6 +306,14 @@ namespace Notification.Core
         }
 
         /// <summary>
+        /// Sets an arbitrary platform-specific content object to display instead of the standard
+        /// title/message layout. The type is platform-dependent (for example, a WPF control).
+        /// </summary>
+        /// <param name="content">The platform-specific content object.</param>
+        /// <returns>The current builder instance for chaining.</returns>
+        public NotificationBuilder WithContent(object content) { _content = content; return this; }
+
+        /// <summary>
         /// Adds a custom extension key-value pair to the notification.
         /// </summary>
         /// <param name="key">The extension key.</param>
@@ -345,6 +355,7 @@ namespace Notification.Core
             OnClose = _onClose,
             Icon = _icon,
             PlatformImage = _platformImage,
+            Content = _content,
             Extensions = _extensions
         };
     }

--- a/src/Notification.Core/Builder/NotificationBuilder.cs
+++ b/src/Notification.Core/Builder/NotificationBuilder.cs
@@ -50,6 +50,8 @@ namespace Notification.Core
         protected Action _onClick;
         /// <summary>The action invoked when the notification is closed.</summary>
         protected Action _onClose;
+        /// <summary>The action invoked when the notification is right-clicked.</summary>
+        protected Action _onRightClick;
         /// <summary>The notification icon.</summary>
         protected object _icon;
         /// <summary>The platform-specific image object.</summary>
@@ -288,6 +290,13 @@ namespace Notification.Core
         public NotificationBuilder OnClose(Action onClose) { _onClose = onClose; return this; }
 
         /// <summary>
+        /// Sets the action invoked when the notification body is right-clicked.
+        /// </summary>
+        /// <param name="onRightClick">The right-click action.</param>
+        /// <returns>The current builder instance for chaining.</returns>
+        public NotificationBuilder OnRightClick(Action onRightClick) { _onRightClick = onRightClick; return this; }
+
+        /// <summary>
         /// Sets the notification icon. The type is platform-dependent.
         /// </summary>
         /// <param name="icon">The icon object.</param>
@@ -353,6 +362,7 @@ namespace Notification.Core
             RightButtonContent = _rightButtonContent,
             OnClick = _onClick,
             OnClose = _onClose,
+            OnRightClick = _onRightClick,
             Icon = _icon,
             PlatformImage = _platformImage,
             Content = _content,

--- a/src/Notification.Core/Builder/NotificationServiceExtensions.cs
+++ b/src/Notification.Core/Builder/NotificationServiceExtensions.cs
@@ -2,8 +2,17 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides extension methods for <see cref="INotificationService"/> to simplify notification creation.
+    /// </summary>
     public static class NotificationServiceExtensions
     {
+        /// <summary>
+        /// Shows a notification configured via a fluent builder action.
+        /// </summary>
+        /// <param name="service">The notification service instance.</param>
+        /// <param name="configure">An action that configures the notification using a <see cref="NotificationBuilder"/>.</param>
+        /// <returns>The unique identifier of the displayed notification.</returns>
         public static Guid Show(this INotificationService service, Action<NotificationBuilder> configure)
         {
             NotificationBuilder builder = NotificationBuilder.Create();

--- a/src/Notification.Core/Configuration/NotificationConfiguration.cs
+++ b/src/Notification.Core/Configuration/NotificationConfiguration.cs
@@ -2,38 +2,149 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides default configuration settings for the notification system, including positioning, sizing, colors, and text formatting.
+    /// </summary>
     public class NotificationConfiguration : INotificationConfiguration
     {
+        /// <summary>
+        /// Gets or sets the screen position where notifications are displayed.
+        /// </summary>
         public NotificationPosition MessagePosition { get; set; } = NotificationPosition.BottomRight;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the notification panel order is reversed. When null, the default behavior is used.
+        /// </summary>
         public bool? IsReversedPanel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum width of a notification in pixels.
+        /// </summary>
         public double MinWidth { get; set; } = 350.0;
+
+        /// <summary>
+        /// Gets or sets the maximum width of a notification in pixels.
+        /// </summary>
         public double MaxWidth { get; set; } = 350.0;
+
+        /// <summary>
+        /// Gets or sets the maximum number of notification overlay windows that can be displayed simultaneously.
+        /// </summary>
         public uint MaxOverlayWindowCount { get; set; } = 999;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether progress bars are automatically collapsed when there are more rows than the limit.
+        /// </summary>
         public bool CollapseProgressIfMoreRows { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the default expiration time for notifications that do not specify one explicitly.
+        /// </summary>
         public TimeSpan DefaultExpirationTime { get; set; } = TimeSpan.FromSeconds(5);
 
+        /// <summary>
+        /// Gets or sets the default background color for notifications without a specific type.
+        /// </summary>
         public NotificationColor DefaultBackgroundColor { get; set; } = NotificationColor.FromHex("#FF444444");
+
+        /// <summary>
+        /// Gets or sets the default foreground (text) color for notifications.
+        /// </summary>
         public NotificationColor DefaultForegroundColor { get; set; } = NotificationColor.WhiteSmoke;
+
+        /// <summary>
+        /// Gets or sets the background color for success notifications.
+        /// </summary>
         public NotificationColor SuccessBackgroundColor { get; set; } = NotificationColor.LimeGreen;
+
+        /// <summary>
+        /// Gets or sets the background color for warning notifications.
+        /// </summary>
         public NotificationColor WarningBackgroundColor { get; set; } = NotificationColor.Orange;
+
+        /// <summary>
+        /// Gets or sets the background color for error notifications.
+        /// </summary>
         public NotificationColor ErrorBackgroundColor { get; set; } = NotificationColor.OrangeRed;
+
+        /// <summary>
+        /// Gets or sets the background color for information notifications.
+        /// </summary>
         public NotificationColor InformationBackgroundColor { get; set; } = NotificationColor.CornflowerBlue;
+
+        /// <summary>
+        /// Gets or sets the default color for progress bar indicators.
+        /// </summary>
         public NotificationColor DefaultProgressColor { get; set; } = NotificationColor.Green;
 
+        /// <summary>
+        /// Gets or sets the base text size in pixels.
+        /// </summary>
         public double BaseTextSize { get; set; } = 14.0;
+
+        /// <summary>
+        /// Gets or sets the title text size in pixels.
+        /// </summary>
         public double TitleSize { get; set; } = 14.0;
+
+        /// <summary>
+        /// Gets or sets the message text size in pixels.
+        /// </summary>
         public double MessageSize { get; set; } = 14.0;
+
+        /// <summary>
+        /// Gets or sets the font family name used for notification text.
+        /// </summary>
         public string FontName { get; set; } = "Segoe UI";
+
+        /// <summary>
+        /// Gets or sets the text alignment for notification titles.
+        /// </summary>
         public NotificationTextAlignment TitleTextAlignment { get; set; } = NotificationTextAlignment.Left;
+
+        /// <summary>
+        /// Gets or sets the text alignment for notification messages.
+        /// </summary>
         public NotificationTextAlignment MessageTextAlignment { get; set; } = NotificationTextAlignment.Left;
+
+        /// <summary>
+        /// Gets or sets the default number of visible text rows before trimming.
+        /// </summary>
         public uint DefaultRowCount { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets the default text trimming type applied to notification text.
+        /// </summary>
         public NotificationTextTrimType DefaultTrimType { get; set; } = NotificationTextTrimType.NoTrim;
 
+        /// <summary>
+        /// Gets or sets the message displayed when an operation is cancelled.
+        /// </summary>
         public string CancellationMessage { get; set; } = "Operation was cancelled";
+
+        /// <summary>
+        /// Gets or sets the label text for the "Open File" action.
+        /// </summary>
         public string OpenFileMessage { get; set; } = "Open File";
+
+        /// <summary>
+        /// Gets or sets the label text for the "Open Folder" action.
+        /// </summary>
         public string OpenFolderMessage { get; set; } = "Open Folder";
+
+        /// <summary>
+        /// Gets or sets the default content for the left button.
+        /// </summary>
         public string DefaultLeftButtonContent { get; set; } = "Ok";
+
+        /// <summary>
+        /// Gets or sets the default content for the right button.
+        /// </summary>
         public string DefaultRightButtonContent { get; set; } = "Cancel";
+
+        /// <summary>
+        /// Gets or sets the default content for the progress bar cancel button.
+        /// </summary>
         public string DefaultProgressButtonContent { get; set; } = "Cancel";
     }
 }

--- a/src/Notification.Core/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Notification.Core/DependencyInjection/ServiceCollectionExtensions.cs
@@ -4,8 +4,17 @@ using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides extension methods for registering core notification services in an <see cref="IServiceCollection"/>.
+    /// </summary>
     public static class NotificationCoreServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the core notification services including configuration, event service, and notification queue.
+        /// </summary>
+        /// <param name="services">The service collection to add the services to.</param>
+        /// <param name="configure">An optional action to customize the notification configuration.</param>
+        /// <returns>The service collection for chaining.</returns>
         public static IServiceCollection AddNotifications(
             this IServiceCollection services,
             Action<INotificationConfiguration> configure = null)

--- a/src/Notification.Core/Enums/Corner.cs
+++ b/src/Notification.Core/Enums/Corner.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies a corner of a rectangular area.
+    /// </summary>
     public enum Corner
     {
+        /// <summary>
+        /// The top-left corner.
+        /// </summary>
         TopLeft,
+
+        /// <summary>
+        /// The top-right corner.
+        /// </summary>
         TopRight,
+
+        /// <summary>
+        /// The bottom-left corner.
+        /// </summary>
         BottomLeft,
+
+        /// <summary>
+        /// The bottom-right corner.
+        /// </summary>
         BottomRight
     }
 }

--- a/src/Notification.Core/Enums/ImagePosition.cs
+++ b/src/Notification.Core/Enums/ImagePosition.cs
@@ -1,9 +1,23 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the position of an image within a notification.
+    /// </summary>
     public enum ImagePosition
     {
+        /// <summary>
+        /// No image is displayed.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// The image is placed at the top of the notification.
+        /// </summary>
         Top,
+
+        /// <summary>
+        /// The image is placed at the bottom of the notification.
+        /// </summary>
         Bottom
     }
 }

--- a/src/Notification.Core/Enums/NotificationFontStyle.cs
+++ b/src/Notification.Core/Enums/NotificationFontStyle.cs
@@ -1,9 +1,23 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the font style for notification text.
+    /// </summary>
     public enum NotificationFontStyle
     {
+        /// <summary>
+        /// Normal upright font style.
+        /// </summary>
         Normal,
+
+        /// <summary>
+        /// Italic font style with characters designed to slant to the right.
+        /// </summary>
         Italic,
+
+        /// <summary>
+        /// Oblique font style with artificially slanted characters.
+        /// </summary>
         Oblique
     }
 }

--- a/src/Notification.Core/Enums/NotificationFontWeight.cs
+++ b/src/Notification.Core/Enums/NotificationFontWeight.cs
@@ -1,15 +1,53 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the weight (thickness) of the font used in notification text.
+    /// </summary>
     public enum NotificationFontWeight
     {
+        /// <summary>
+        /// Thin font weight (100).
+        /// </summary>
         Thin = 100,
+
+        /// <summary>
+        /// Extra-light font weight (200).
+        /// </summary>
         ExtraLight = 200,
+
+        /// <summary>
+        /// Light font weight (300).
+        /// </summary>
         Light = 300,
+
+        /// <summary>
+        /// Normal (regular) font weight (400).
+        /// </summary>
         Normal = 400,
+
+        /// <summary>
+        /// Medium font weight (500).
+        /// </summary>
         Medium = 500,
+
+        /// <summary>
+        /// Semi-bold font weight (600).
+        /// </summary>
         SemiBold = 600,
+
+        /// <summary>
+        /// Bold font weight (700).
+        /// </summary>
         Bold = 700,
+
+        /// <summary>
+        /// Extra-bold font weight (800).
+        /// </summary>
         ExtraBold = 800,
+
+        /// <summary>
+        /// Black (heavy) font weight (900).
+        /// </summary>
         Black = 900
     }
 }

--- a/src/Notification.Core/Enums/NotificationHorizontalAlignment.cs
+++ b/src/Notification.Core/Enums/NotificationHorizontalAlignment.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the horizontal alignment of content within a notification.
+    /// </summary>
     public enum NotificationHorizontalAlignment
     {
+        /// <summary>
+        /// Content is aligned to the left.
+        /// </summary>
         Left,
+
+        /// <summary>
+        /// Content is centered horizontally.
+        /// </summary>
         Center,
+
+        /// <summary>
+        /// Content is aligned to the right.
+        /// </summary>
         Right,
+
+        /// <summary>
+        /// Content is stretched to fill the available horizontal space.
+        /// </summary>
         Stretch
     }
 }

--- a/src/Notification.Core/Enums/NotificationLifecycleStage.cs
+++ b/src/Notification.Core/Enums/NotificationLifecycleStage.cs
@@ -1,11 +1,33 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents the lifecycle stage of a notification.
+    /// </summary>
     public enum NotificationLifecycleStage
     {
+        /// <summary>
+        /// The notification has been displayed to the user.
+        /// </summary>
         Shown,
+
+        /// <summary>
+        /// The notification was clicked by the user.
+        /// </summary>
         Clicked,
+
+        /// <summary>
+        /// The notification was explicitly closed.
+        /// </summary>
         Closed,
+
+        /// <summary>
+        /// The notification expired after its display duration elapsed.
+        /// </summary>
         TimedOut,
+
+        /// <summary>
+        /// The notification was dismissed by the user.
+        /// </summary>
         Dismissed
     }
 }

--- a/src/Notification.Core/Enums/NotificationPosition.cs
+++ b/src/Notification.Core/Enums/NotificationPosition.cs
@@ -1,16 +1,58 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the screen position where notifications are displayed.
+    /// </summary>
     public enum NotificationPosition
     {
+        /// <summary>
+        /// Top-left corner of the screen.
+        /// </summary>
         TopLeft,
+
+        /// <summary>
+        /// Top-right corner of the screen.
+        /// </summary>
         TopRight,
+
+        /// <summary>
+        /// Top-center of the screen.
+        /// </summary>
         TopCenter,
+
+        /// <summary>
+        /// Bottom-left corner of the screen.
+        /// </summary>
         BottomLeft,
+
+        /// <summary>
+        /// Bottom-right corner of the screen.
+        /// </summary>
         BottomRight,
+
+        /// <summary>
+        /// Bottom-center of the screen.
+        /// </summary>
         BottomCenter,
+
+        /// <summary>
+        /// Center-left edge of the screen.
+        /// </summary>
         CenterLeft,
+
+        /// <summary>
+        /// Center-right edge of the screen.
+        /// </summary>
         CenterRight,
+
+        /// <summary>
+        /// Center of the screen.
+        /// </summary>
         Center,
+
+        /// <summary>
+        /// An absolute position specified by explicit coordinates.
+        /// </summary>
         Absolute
     }
 }

--- a/src/Notification.Core/Enums/NotificationPriority.cs
+++ b/src/Notification.Core/Enums/NotificationPriority.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the priority level of a notification, affecting its display order.
+    /// </summary>
     public enum NotificationPriority
     {
+        /// <summary>
+        /// Low priority; displayed after higher-priority notifications.
+        /// </summary>
         Low = 0,
+
+        /// <summary>
+        /// Normal (default) priority.
+        /// </summary>
         Normal = 1,
+
+        /// <summary>
+        /// High priority; displayed before normal and low-priority notifications.
+        /// </summary>
         High = 2,
+
+        /// <summary>
+        /// Critical priority; displayed immediately above all other notifications.
+        /// </summary>
         Critical = 3
     }
 }

--- a/src/Notification.Core/Enums/NotificationTextAlignment.cs
+++ b/src/Notification.Core/Enums/NotificationTextAlignment.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the horizontal text alignment within a notification.
+    /// </summary>
     public enum NotificationTextAlignment
     {
+        /// <summary>
+        /// Text is aligned to the left edge.
+        /// </summary>
         Left,
+
+        /// <summary>
+        /// Text is centered horizontally.
+        /// </summary>
         Center,
+
+        /// <summary>
+        /// Text is aligned to the right edge.
+        /// </summary>
         Right,
+
+        /// <summary>
+        /// Text is justified, stretching to fill the available width.
+        /// </summary>
         Justify
     }
 }

--- a/src/Notification.Core/Enums/NotificationTextTrimType.cs
+++ b/src/Notification.Core/Enums/NotificationTextTrimType.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies how notification text is trimmed when it exceeds the available space.
+    /// </summary>
     public enum NotificationTextTrimType
     {
+        /// <summary>
+        /// No trimming is applied; text is displayed in full.
+        /// </summary>
         NoTrim,
+
+        /// <summary>
+        /// Text is trimmed with an ellipsis when it exceeds the available space.
+        /// </summary>
         Trim,
+
+        /// <summary>
+        /// A "more" link or indicator is attached to the trimmed text.
+        /// </summary>
         Attach,
+
+        /// <summary>
+        /// A "more" link or indicator is attached only when the text exceeds the maximum number of rows.
+        /// </summary>
         AttachIfMoreRows
     }
 }

--- a/src/Notification.Core/Enums/NotificationType.cs
+++ b/src/Notification.Core/Enums/NotificationType.cs
@@ -1,12 +1,38 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the type of a notification, which determines its visual appearance and semantics.
+    /// </summary>
     public enum NotificationType
     {
+        /// <summary>
+        /// No specific type; uses default styling.
+        /// </summary>
         None,
+
+        /// <summary>
+        /// An informational notification.
+        /// </summary>
         Information,
+
+        /// <summary>
+        /// A success notification indicating a completed operation.
+        /// </summary>
         Success,
+
+        /// <summary>
+        /// A warning notification indicating a potential issue.
+        /// </summary>
         Warning,
+
+        /// <summary>
+        /// An error notification indicating a failure or critical issue.
+        /// </summary>
         Error,
+
+        /// <summary>
+        /// A general-purpose notification.
+        /// </summary>
         Notification
     }
 }

--- a/src/Notification.Core/Enums/NotificationVerticalAlignment.cs
+++ b/src/Notification.Core/Enums/NotificationVerticalAlignment.cs
@@ -1,10 +1,28 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Specifies the vertical alignment of content within a notification.
+    /// </summary>
     public enum NotificationVerticalAlignment
     {
+        /// <summary>
+        /// Content is aligned to the top.
+        /// </summary>
         Top,
+
+        /// <summary>
+        /// Content is centered vertically.
+        /// </summary>
         Center,
+
+        /// <summary>
+        /// Content is aligned to the bottom.
+        /// </summary>
         Bottom,
+
+        /// <summary>
+        /// Content is stretched to fill the available vertical space.
+        /// </summary>
         Stretch
     }
 }

--- a/src/Notification.Core/Events/INotificationEventService.cs
+++ b/src/Notification.Core/Events/INotificationEventService.cs
@@ -2,13 +2,35 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides events for tracking notification lifecycle changes.
+    /// </summary>
     public interface INotificationEventService
     {
+        /// <summary>
+        /// Occurs when any notification lifecycle stage changes.
+        /// </summary>
         event EventHandler<NotificationLifecycleEventArgs> NotificationLifecycleChanged;
+
+        /// <summary>
+        /// Occurs when a notification is displayed to the user.
+        /// </summary>
         event EventHandler<NotificationLifecycleEventArgs> NotificationShown;
+
+        /// <summary>
+        /// Occurs when a notification is closed or dismissed.
+        /// </summary>
         event EventHandler<NotificationLifecycleEventArgs> NotificationClosed;
+
+        /// <summary>
+        /// Occurs when a notification is clicked by the user.
+        /// </summary>
         event EventHandler<NotificationLifecycleEventArgs> NotificationClicked;
 
+        /// <summary>
+        /// Raises a notification lifecycle event.
+        /// </summary>
+        /// <param name="args">The event arguments containing the notification identifier and lifecycle stage.</param>
         void Raise(NotificationLifecycleEventArgs args);
     }
 }

--- a/src/Notification.Core/Events/NotificationEventService.cs
+++ b/src/Notification.Core/Events/NotificationEventService.cs
@@ -2,13 +2,35 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides a centralized service for raising and subscribing to notification lifecycle events.
+    /// </summary>
     public class NotificationEventService : INotificationEventService
     {
+        /// <summary>
+        /// Occurs when any notification lifecycle stage changes.
+        /// </summary>
         public event EventHandler<NotificationLifecycleEventArgs> NotificationLifecycleChanged;
+
+        /// <summary>
+        /// Occurs when a notification is displayed to the user.
+        /// </summary>
         public event EventHandler<NotificationLifecycleEventArgs> NotificationShown;
+
+        /// <summary>
+        /// Occurs when a notification is closed for any reason (explicit close, timeout, or dismissal).
+        /// </summary>
         public event EventHandler<NotificationLifecycleEventArgs> NotificationClosed;
+
+        /// <summary>
+        /// Occurs when a notification is clicked by the user.
+        /// </summary>
         public event EventHandler<NotificationLifecycleEventArgs> NotificationClicked;
 
+        /// <summary>
+        /// Raises the appropriate lifecycle events based on the notification stage.
+        /// </summary>
+        /// <param name="args">The event arguments containing notification details and the lifecycle stage.</param>
         public void Raise(NotificationLifecycleEventArgs args)
         {
             NotificationLifecycleChanged?.Invoke(this, args);

--- a/src/Notification.Core/Events/NotificationLifecycleEventArgs.cs
+++ b/src/Notification.Core/Events/NotificationLifecycleEventArgs.cs
@@ -2,14 +2,43 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides event data for notification lifecycle events such as shown, clicked, closed, and dismissed.
+    /// </summary>
     public sealed class NotificationLifecycleEventArgs : EventArgs
     {
+        /// <summary>
+        /// Gets the unique identifier of the notification that triggered this event.
+        /// </summary>
         public Guid NotificationId { get; }
+
+        /// <summary>
+        /// Gets the lifecycle stage that the notification has entered.
+        /// </summary>
         public NotificationLifecycleStage Stage { get; }
+
+        /// <summary>
+        /// Gets the UTC timestamp when this lifecycle event occurred.
+        /// </summary>
         public DateTimeOffset Timestamp { get; }
+
+        /// <summary>
+        /// Gets the title of the notification at the time of the event.
+        /// </summary>
         public string Title { get; }
+
+        /// <summary>
+        /// Gets the message of the notification at the time of the event.
+        /// </summary>
         public string Message { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationLifecycleEventArgs"/> class.
+        /// </summary>
+        /// <param name="notificationId">The unique identifier of the notification.</param>
+        /// <param name="stage">The lifecycle stage that the notification has entered.</param>
+        /// <param name="title">The notification title.</param>
+        /// <param name="message">The notification message.</param>
         public NotificationLifecycleEventArgs(
             Guid notificationId,
             NotificationLifecycleStage stage,

--- a/src/Notification.Core/Interfaces/INotificationConfiguration.cs
+++ b/src/Notification.Core/Interfaces/INotificationConfiguration.cs
@@ -2,38 +2,149 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides configuration options for the notification system appearance and behavior.
+    /// </summary>
     public interface INotificationConfiguration
     {
+        /// <summary>
+        /// Gets or sets the position on screen where notifications are displayed.
+        /// </summary>
         NotificationPosition MessagePosition { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether the notification panel stacking order is reversed.
+        /// </summary>
         bool? IsReversedPanel { get; set; }
+
+        /// <summary>
+        /// Gets or sets the minimum width of the notification window in pixels.
+        /// </summary>
         double MinWidth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum width of the notification window in pixels.
+        /// </summary>
         double MaxWidth { get; set; }
+
+        /// <summary>
+        /// Gets or sets the maximum number of overlay notification windows displayed simultaneously.
+        /// </summary>
         uint MaxOverlayWindowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets whether to collapse progress notifications when more rows are displayed than allowed.
+        /// </summary>
         bool CollapseProgressIfMoreRows { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default time after which a notification automatically expires.
+        /// </summary>
         TimeSpan DefaultExpirationTime { get; set; }
 
+        /// <summary>
+        /// Gets or sets the default background color for notifications.
+        /// </summary>
         NotificationColor DefaultBackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default foreground (text) color for notifications.
+        /// </summary>
         NotificationColor DefaultForegroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color for success notifications.
+        /// </summary>
         NotificationColor SuccessBackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color for warning notifications.
+        /// </summary>
         NotificationColor WarningBackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color for error notifications.
+        /// </summary>
         NotificationColor ErrorBackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the background color for informational notifications.
+        /// </summary>
         NotificationColor InformationBackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default color for progress indicators.
+        /// </summary>
         NotificationColor DefaultProgressColor { get; set; }
 
+        /// <summary>
+        /// Gets or sets the base text size in pixels used as a reference for scaling.
+        /// </summary>
         double BaseTextSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the font size for notification titles in pixels.
+        /// </summary>
         double TitleSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the font size for notification messages in pixels.
+        /// </summary>
         double MessageSize { get; set; }
+
+        /// <summary>
+        /// Gets or sets the font family name used for notification text.
+        /// </summary>
         string FontName { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text alignment for notification titles.
+        /// </summary>
         NotificationTextAlignment TitleTextAlignment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text alignment for notification messages.
+        /// </summary>
         NotificationTextAlignment MessageTextAlignment { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default number of visible text rows in a notification.
+        /// </summary>
         uint DefaultRowCount { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default text trimming type when content exceeds available space.
+        /// </summary>
         NotificationTextTrimType DefaultTrimType { get; set; }
 
+        /// <summary>
+        /// Gets or sets the display text for the cancellation action.
+        /// </summary>
         string CancellationMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text for the open file action.
+        /// </summary>
         string OpenFileMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the display text for the open folder action.
+        /// </summary>
         string OpenFolderMessage { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default content displayed on the left button.
+        /// </summary>
         string DefaultLeftButtonContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default content displayed on the right button.
+        /// </summary>
         string DefaultRightButtonContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default content displayed on the progress action button.
+        /// </summary>
         string DefaultProgressButtonContent { get; set; }
     }
 }

--- a/src/Notification.Core/Interfaces/INotificationContent.cs
+++ b/src/Notification.Core/Interfaces/INotificationContent.cs
@@ -2,23 +2,89 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents the content and visual configuration of a notification.
+    /// </summary>
     public interface INotificationContent
     {
+        /// <summary>
+        /// Gets the title text displayed at the top of the notification.
+        /// </summary>
         string Title { get; }
+
+        /// <summary>
+        /// Gets the message body text of the notification.
+        /// </summary>
         string Message { get; }
+
+        /// <summary>
+        /// Gets the type of the notification (e.g., success, warning, error, information).
+        /// </summary>
         NotificationType Type { get; }
+
+        /// <summary>
+        /// Gets the custom background color override for the notification, or <c>null</c> to use the default.
+        /// </summary>
         NotificationColor? BackgroundColor { get; }
+
+        /// <summary>
+        /// Gets the custom foreground color override for the notification, or <c>null</c> to use the default.
+        /// </summary>
         NotificationColor? ForegroundColor { get; }
+
+        /// <summary>
+        /// Gets the text trimming type applied when content exceeds available space.
+        /// </summary>
         NotificationTextTrimType TrimType { get; }
+
+        /// <summary>
+        /// Gets the maximum number of visible text rows in the notification.
+        /// </summary>
         uint RowsCount { get; }
+
+        /// <summary>
+        /// Gets the text display settings for the notification title.
+        /// </summary>
         NotificationTextSettings TitleSettings { get; }
+
+        /// <summary>
+        /// Gets the text display settings for the notification message.
+        /// </summary>
         NotificationTextSettings MessageSettings { get; }
+
+        /// <summary>
+        /// Gets the icon displayed in the notification.
+        /// </summary>
         object Icon { get; }
+
+        /// <summary>
+        /// Gets the image data displayed in the notification.
+        /// </summary>
         NotificationImageData Image { get; }
+
+        /// <summary>
+        /// Gets the action invoked when the left button is clicked.
+        /// </summary>
         Action LeftButtonAction { get; }
+
+        /// <summary>
+        /// Gets the content displayed on the left button.
+        /// </summary>
         object LeftButtonContent { get; }
+
+        /// <summary>
+        /// Gets the action invoked when the right button is clicked.
+        /// </summary>
         Action RightButtonAction { get; }
+
+        /// <summary>
+        /// Gets the content displayed on the right button.
+        /// </summary>
         object RightButtonContent { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the notification is dismissed when clicked.
+        /// </summary>
         bool CloseOnClick { get; }
     }
 }

--- a/src/Notification.Core/Interfaces/INotificationService.cs
+++ b/src/Notification.Core/Interfaces/INotificationService.cs
@@ -2,10 +2,27 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides methods for displaying and managing notifications.
+    /// </summary>
     public interface INotificationService
     {
+        /// <summary>
+        /// Displays a notification based on the specified request.
+        /// </summary>
+        /// <param name="request">The notification request containing content and configuration.</param>
+        /// <returns>A unique identifier for the displayed notification.</returns>
         Guid Show(NotificationRequest request);
+
+        /// <summary>
+        /// Dismisses a specific notification by its identifier.
+        /// </summary>
+        /// <param name="notificationId">The unique identifier of the notification to dismiss.</param>
         void Dismiss(Guid notificationId);
+
+        /// <summary>
+        /// Dismisses all currently displayed notifications.
+        /// </summary>
         void DismissAll();
     }
 }

--- a/src/Notification.Core/Interfaces/INotifierProgress.cs
+++ b/src/Notification.Core/Interfaces/INotifierProgress.cs
@@ -3,11 +3,29 @@ using System.Threading;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents a progress reporter for notification-based operations with cancellation and timing support.
+    /// </summary>
     public interface INotifierProgress : IProgress<NotificationProgressReport>, IDisposable
     {
+        /// <summary>
+        /// Gets a value indicating whether the associated operation has finished.
+        /// </summary>
         bool IsFinished { get; }
+
+        /// <summary>
+        /// Gets the cancellation token that signals when the operation should be cancelled.
+        /// </summary>
         CancellationToken CancellationToken { get; }
+
+        /// <summary>
+        /// Gets the cancellation token source used to trigger cancellation of the operation.
+        /// </summary>
         CancellationTokenSource CancelSource { get; }
+
+        /// <summary>
+        /// Gets the timer that tracks the elapsed waiting time of the operation.
+        /// </summary>
         OperationTimer WaitingTimer { get; }
     }
 }

--- a/src/Notification.Core/Models/NotificationContentData.cs
+++ b/src/Notification.Core/Models/NotificationContentData.cs
@@ -2,23 +2,89 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents the content data for a notification, including text, colors, buttons, and media.
+    /// </summary>
     public class NotificationContentData : INotificationContent
     {
+        /// <summary>
+        /// Gets or sets the notification title text.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification message body text.
+        /// </summary>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification type that determines the visual style.
+        /// </summary>
         public NotificationType Type { get; set; } = NotificationType.None;
+
+        /// <summary>
+        /// Gets or sets the custom background color. When null, the default color from configuration is used.
+        /// </summary>
         public NotificationColor? BackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom foreground (text) color. When null, the default color from configuration is used.
+        /// </summary>
         public NotificationColor? ForegroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text trimming type applied to the notification message.
+        /// </summary>
         public NotificationTextTrimType TrimType { get; set; } = NotificationTextTrimType.NoTrim;
+
+        /// <summary>
+        /// Gets or sets the maximum number of visible text rows before trimming is applied.
+        /// </summary>
         public uint RowsCount { get; set; } = 2;
+
+        /// <summary>
+        /// Gets or sets the text rendering settings for the title.
+        /// </summary>
         public NotificationTextSettings TitleSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text rendering settings for the message.
+        /// </summary>
         public NotificationTextSettings MessageSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon displayed in the notification. The type is platform-dependent.
+        /// </summary>
         public object Icon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the image data displayed in the notification.
+        /// </summary>
         public NotificationImageData Image { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action invoked when the left button is clicked.
+        /// </summary>
         public Action LeftButtonAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content displayed on the left button.
+        /// </summary>
         public object LeftButtonContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action invoked when the right button is clicked.
+        /// </summary>
         public Action RightButtonAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the content displayed on the right button.
+        /// </summary>
         public object RightButtonContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the notification is closed when clicked.
+        /// </summary>
         public bool CloseOnClick { get; set; } = true;
     }
 }

--- a/src/Notification.Core/Models/NotificationProgressReport.cs
+++ b/src/Notification.Core/Models/NotificationProgressReport.cs
@@ -39,5 +39,77 @@ namespace Notification.Core
             Title = title;
             ShowCancel = showCancel;
         }
+
+        /// <summary>
+        /// Initializes a new determinate progress report with only a value.
+        /// </summary>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        public NotificationProgressReport(double value)
+            : this(value, null, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new determinate progress report with a value and a status message.
+        /// </summary>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        /// <param name="message">The progress status message.</param>
+        public NotificationProgressReport(double value, string message)
+            : this(value, message, null, null)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new determinate progress report with a value, a status message and a title.
+        /// </summary>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        public NotificationProgressReport(double value, string message, string title)
+            : this(value, message, title, null)
+        {
+        }
+
+        /// <summary>
+        /// Creates an indeterminate progress report that carries no numeric value.
+        /// </summary>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        /// <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        /// <returns>An indeterminate <see cref="NotificationProgressReport"/>.</returns>
+        public static NotificationProgressReport Indeterminate(string message = null, string title = null, bool? showCancel = null)
+            => new NotificationProgressReport(null, message, title, showCancel);
+
+        /// <summary>
+        /// Returns a copy of this report with the specified progress value.
+        /// </summary>
+        /// <param name="value">The new progress value, or null for indeterminate.</param>
+        /// <returns>A new <see cref="NotificationProgressReport"/> with the updated value.</returns>
+        public NotificationProgressReport WithValue(double? value)
+            => new NotificationProgressReport(value, Message, Title, ShowCancel);
+
+        /// <summary>
+        /// Returns a copy of this report with the specified status message.
+        /// </summary>
+        /// <param name="message">The new status message.</param>
+        /// <returns>A new <see cref="NotificationProgressReport"/> with the updated message.</returns>
+        public NotificationProgressReport WithMessage(string message)
+            => new NotificationProgressReport(Value, message, Title, ShowCancel);
+
+        /// <summary>
+        /// Returns a copy of this report with the specified title.
+        /// </summary>
+        /// <param name="title">The new title.</param>
+        /// <returns>A new <see cref="NotificationProgressReport"/> with the updated title.</returns>
+        public NotificationProgressReport WithTitle(string title)
+            => new NotificationProgressReport(Value, Message, title, ShowCancel);
+
+        /// <summary>
+        /// Returns a copy of this report with the specified cancel button visibility.
+        /// </summary>
+        /// <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        /// <returns>A new <see cref="NotificationProgressReport"/> with the updated cancel button visibility.</returns>
+        public NotificationProgressReport WithShowCancel(bool? showCancel)
+            => new NotificationProgressReport(Value, Message, Title, showCancel);
     }
 }

--- a/src/Notification.Core/Models/NotificationProgressReport.cs
+++ b/src/Notification.Core/Models/NotificationProgressReport.cs
@@ -1,12 +1,37 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents an immutable progress report for a notification progress bar.
+    /// </summary>
     public readonly struct NotificationProgressReport
     {
+        /// <summary>
+        /// Gets the progress value as a percentage (0-100), or null if indeterminate.
+        /// </summary>
         public double? Value { get; }
+
+        /// <summary>
+        /// Gets the progress status message displayed to the user.
+        /// </summary>
         public string Message { get; }
+
+        /// <summary>
+        /// Gets the progress bar title text.
+        /// </summary>
         public string Title { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the cancel button should be shown, or null to keep the current state.
+        /// </summary>
         public bool? ShowCancel { get; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationProgressReport"/> struct.
+        /// </summary>
+        /// <param name="value">The progress value as a percentage (0-100), or null for indeterminate.</param>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        /// <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
         public NotificationProgressReport(double? value, string message, string title, bool? showCancel)
         {
             Value = value;

--- a/src/Notification.Core/Models/NotificationRequest.cs
+++ b/src/Notification.Core/Models/NotificationRequest.cs
@@ -3,40 +3,134 @@ using System.Collections.Generic;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents a complete request to display a notification, including all visual and behavioral options.
+    /// </summary>
     public sealed class NotificationRequest
     {
+        /// <summary>
+        /// Gets or sets the unique identifier for this notification request.
+        /// </summary>
         public Guid Id { get; set; } = Guid.NewGuid();
 
+        /// <summary>
+        /// Gets or sets the notification title text.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification message body text.
+        /// </summary>
         public string Message { get; set; }
+
+        /// <summary>
+        /// Gets or sets the notification type that determines the visual style.
+        /// </summary>
         public NotificationType Type { get; set; } = NotificationType.None;
 
+        /// <summary>
+        /// Gets or sets the name of the notification area where this notification should be displayed.
+        /// </summary>
         public string AreaName { get; set; } = "";
+
+        /// <summary>
+        /// Gets or sets the duration after which the notification automatically closes. When null, the default expiration time from configuration is used.
+        /// </summary>
         public TimeSpan? ExpirationTime { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the notification is closed when clicked.
+        /// </summary>
         public bool CloseOnClick { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the close button is visible.
+        /// </summary>
         public bool ShowCloseButton { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the display priority of this notification.
+        /// </summary>
         public NotificationPriority Priority { get; set; } = NotificationPriority.Normal;
+
+        /// <summary>
+        /// Gets or sets the group key used to deduplicate notifications. Notifications with the same group key replace each other.
+        /// </summary>
         public string GroupKey { get; set; }
 
+        /// <summary>
+        /// Gets or sets the custom background color. When null, the default color from configuration is used.
+        /// </summary>
         public NotificationColor? BackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom foreground (text) color. When null, the default color from configuration is used.
+        /// </summary>
         public NotificationColor? ForegroundColor { get; set; }
 
+        /// <summary>
+        /// Gets or sets the text rendering settings for the title.
+        /// </summary>
         public NotificationTextSettings TitleSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text rendering settings for the message.
+        /// </summary>
         public NotificationTextSettings MessageSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text trimming type applied to the notification message.
+        /// </summary>
         public NotificationTextTrimType TrimType { get; set; } = NotificationTextTrimType.NoTrim;
+
+        /// <summary>
+        /// Gets or sets the maximum number of visible text rows before trimming is applied.
+        /// </summary>
         public uint RowsCount { get; set; } = 2;
 
+        /// <summary>
+        /// Gets or sets the action invoked when the left button is clicked.
+        /// </summary>
         public Action LeftButtonAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text content displayed on the left button.
+        /// </summary>
         public string LeftButtonContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action invoked when the right button is clicked.
+        /// </summary>
         public Action RightButtonAction { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text content displayed on the right button.
+        /// </summary>
         public string RightButtonContent { get; set; }
 
+        /// <summary>
+        /// Gets or sets the action invoked when the notification body is clicked.
+        /// </summary>
         public Action OnClick { get; set; }
+
+        /// <summary>
+        /// Gets or sets the action invoked when the notification is closed.
+        /// </summary>
         public Action OnClose { get; set; }
 
+        /// <summary>
+        /// Gets or sets the icon displayed in the notification. The type is platform-dependent.
+        /// </summary>
         public object Icon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the platform-specific image object for the notification.
+        /// </summary>
         public object PlatformImage { get; set; }
 
+        /// <summary>
+        /// Gets or sets a dictionary of custom extension data attached to this notification.
+        /// </summary>
         public IDictionary<string, object> Extensions { get; set; }
     }
 }

--- a/src/Notification.Core/Models/NotificationRequest.cs
+++ b/src/Notification.Core/Models/NotificationRequest.cs
@@ -129,6 +129,13 @@ namespace Notification.Core
         public object PlatformImage { get; set; }
 
         /// <summary>
+        /// Gets or sets an arbitrary platform-specific content object displayed instead of the
+        /// standard title/message layout. The type is platform-dependent (for example, a WPF control).
+        /// When set, the title, message and related text options are ignored.
+        /// </summary>
+        public object Content { get; set; }
+
+        /// <summary>
         /// Gets or sets a dictionary of custom extension data attached to this notification.
         /// </summary>
         public IDictionary<string, object> Extensions { get; set; }

--- a/src/Notification.Core/Models/NotificationRequest.cs
+++ b/src/Notification.Core/Models/NotificationRequest.cs
@@ -119,6 +119,11 @@ namespace Notification.Core
         public Action OnClose { get; set; }
 
         /// <summary>
+        /// Gets or sets the action invoked when the notification body is right-clicked.
+        /// </summary>
+        public Action OnRightClick { get; set; }
+
+        /// <summary>
         /// Gets or sets the icon displayed in the notification. The type is platform-dependent.
         /// </summary>
         public object Icon { get; set; }

--- a/src/Notification.Core/Models/ProgressBarOptions.cs
+++ b/src/Notification.Core/Models/ProgressBarOptions.cs
@@ -1,22 +1,88 @@
 namespace Notification.Core
 {
+    /// <summary>
+    /// Represents configuration options for a progress bar notification.
+    /// </summary>
     public class ProgressBarOptions
     {
+        /// <summary>
+        /// Gets or sets the progress bar title text.
+        /// </summary>
         public string Title { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the cancel button is shown.
+        /// </summary>
         public bool ShowCancelButton { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the progress bar is visible.
+        /// </summary>
         public bool ShowProgress { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the name of the notification area where the progress bar is displayed.
+        /// </summary>
         public string AreaName { get; set; } = "";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether long text should be trimmed.
+        /// </summary>
         public bool TrimText { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default number of visible text rows.
+        /// </summary>
         public uint DefaultRowsCount { get; set; } = 1;
+
+        /// <summary>
+        /// Gets or sets the base message displayed while calculating estimated remaining time.
+        /// </summary>
         public string BaseWaitingMessage { get; set; } = "Calculation time";
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the progress bar can be collapsed.
+        /// </summary>
         public bool IsCollapse { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the title is shown when the progress bar is collapsed.
+        /// </summary>
         public bool TitleWhenCollapsed { get; set; } = true;
+
+        /// <summary>
+        /// Gets or sets the custom background color for the progress bar notification.
+        /// </summary>
         public NotificationColor? BackgroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the custom foreground (text) color for the progress bar notification.
+        /// </summary>
         public NotificationColor? ForegroundColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the progress indicator.
+        /// </summary>
         public NotificationColor? ProgressColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the icon displayed in the progress bar notification. The type is platform-dependent.
+        /// </summary>
         public object Icon { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text rendering settings for the title.
+        /// </summary>
         public NotificationTextSettings TitleSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text rendering settings for the message.
+        /// </summary>
         public NotificationTextSettings MessageSettings { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the close button is visible.
+        /// </summary>
         public bool ShowCloseButton { get; set; } = true;
     }
 }

--- a/src/Notification.Core/Notification.Core.xml
+++ b/src/Notification.Core/Notification.Core.xml
@@ -290,6 +290,9 @@
         <member name="F:Notification.Core.NotificationBuilder._platformImage">
             <summary>The platform-specific image object.</summary>
         </member>
+        <member name="F:Notification.Core.NotificationBuilder._content">
+            <summary>The arbitrary platform-specific content object.</summary>
+        </member>
         <member name="F:Notification.Core.NotificationBuilder._extensions">
             <summary>The collection of platform-specific extension values.</summary>
         </member>
@@ -506,6 +509,14 @@
             Sets the notification image.
             </summary>
             <param name="image">The image data to display in the notification.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithContent(System.Object)">
+            <summary>
+            Sets an arbitrary platform-specific content object to display instead of the standard
+            title/message layout. The type is platform-dependent (for example, a WPF control).
+            </summary>
+            <param name="content">The platform-specific content object.</param>
             <returns>The current builder instance for chaining.</returns>
         </member>
         <member name="M:Notification.Core.NotificationBuilder.WithExtension(System.String,System.Object)">
@@ -1732,6 +1743,13 @@
         <member name="P:Notification.Core.NotificationRequest.PlatformImage">
             <summary>
             Gets or sets the platform-specific image object for the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Content">
+            <summary>
+            Gets or sets an arbitrary platform-specific content object displayed instead of the
+            standard title/message layout. The type is platform-dependent (for example, a WPF control).
+            When set, the title, message and related text options are ignored.
             </summary>
         </member>
         <member name="P:Notification.Core.NotificationRequest.Extensions">

--- a/src/Notification.Core/Notification.Core.xml
+++ b/src/Notification.Core/Notification.Core.xml
@@ -1551,6 +1551,64 @@
             <param name="title">The progress bar title.</param>
             <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
         </member>
+        <member name="M:Notification.Core.NotificationProgressReport.#ctor(System.Double)">
+            <summary>
+            Initializes a new determinate progress report with only a value.
+            </summary>
+            <param name="value">The progress value as a percentage (0-100).</param>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.#ctor(System.Double,System.String)">
+            <summary>
+            Initializes a new determinate progress report with a value and a status message.
+            </summary>
+            <param name="value">The progress value as a percentage (0-100).</param>
+            <param name="message">The progress status message.</param>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.#ctor(System.Double,System.String,System.String)">
+            <summary>
+            Initializes a new determinate progress report with a value, a status message and a title.
+            </summary>
+            <param name="value">The progress value as a percentage (0-100).</param>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.Indeterminate(System.String,System.String,System.Nullable{System.Boolean})">
+            <summary>
+            Creates an indeterminate progress report that carries no numeric value.
+            </summary>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+            <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+            <returns>An indeterminate <see cref="T:Notification.Core.NotificationProgressReport"/>.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.WithValue(System.Nullable{System.Double})">
+            <summary>
+            Returns a copy of this report with the specified progress value.
+            </summary>
+            <param name="value">The new progress value, or null for indeterminate.</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationProgressReport"/> with the updated value.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.WithMessage(System.String)">
+            <summary>
+            Returns a copy of this report with the specified status message.
+            </summary>
+            <param name="message">The new status message.</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationProgressReport"/> with the updated message.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.WithTitle(System.String)">
+            <summary>
+            Returns a copy of this report with the specified title.
+            </summary>
+            <param name="title">The new title.</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationProgressReport"/> with the updated title.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.WithShowCancel(System.Nullable{System.Boolean})">
+            <summary>
+            Returns a copy of this report with the specified cancel button visibility.
+            </summary>
+            <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationProgressReport"/> with the updated cancel button visibility.</returns>
+        </member>
         <member name="T:Notification.Core.NotificationRequest">
             <summary>
             Represents a complete request to display a notification, including all visual and behavioral options.
@@ -1878,6 +1936,55 @@
             <param name="progress">The target progress reporter. If null, returns null.</param>
             <param name="selector">A function that transforms the source value to the target type.</param>
             <returns>An <see cref="T:System.IProgress`1"/> that projects values to the target progress, or null if the input progress is null.</returns>
+        </member>
+        <member name="T:Notification.Core.ProgressReportExtensions">
+            <summary>
+            Provides convenience extension methods for reporting <see cref="T:Notification.Core.NotificationProgressReport"/>
+            values without constructing the struct manually.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.ProgressReportExtensions.Report(System.IProgress{Notification.Core.NotificationProgressReport},System.Double)">
+            <summary>
+            Reports a determinate progress update with only a value.
+            </summary>
+            <param name="progress">The progress reporter. The call is ignored when null.</param>
+            <param name="value">The progress value as a percentage (0-100).</param>
+        </member>
+        <member name="M:Notification.Core.ProgressReportExtensions.Report(System.IProgress{Notification.Core.NotificationProgressReport},System.Double,System.String)">
+            <summary>
+            Reports a determinate progress update with a value and a status message.
+            </summary>
+            <param name="progress">The progress reporter. The call is ignored when null.</param>
+            <param name="value">The progress value as a percentage (0-100).</param>
+            <param name="message">The progress status message.</param>
+        </member>
+        <member name="M:Notification.Core.ProgressReportExtensions.Report(System.IProgress{Notification.Core.NotificationProgressReport},System.Double,System.String,System.String)">
+            <summary>
+            Reports a determinate progress update with a value, a status message and a title.
+            </summary>
+            <param name="progress">The progress reporter. The call is ignored when null.</param>
+            <param name="value">The progress value as a percentage (0-100).</param>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+        </member>
+        <member name="M:Notification.Core.ProgressReportExtensions.Report(System.IProgress{Notification.Core.NotificationProgressReport},System.Double,System.String,System.String,System.Nullable{System.Boolean})">
+            <summary>
+            Reports a determinate progress update with a value, a status message, a title and cancel button visibility.
+            </summary>
+            <param name="progress">The progress reporter. The call is ignored when null.</param>
+            <param name="value">The progress value as a percentage (0-100).</param>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+            <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        </member>
+        <member name="M:Notification.Core.ProgressReportExtensions.ReportIndeterminate(System.IProgress{Notification.Core.NotificationProgressReport},System.String,System.String,System.Nullable{System.Boolean})">
+            <summary>
+            Reports an indeterminate progress update that carries no numeric value.
+            </summary>
+            <param name="progress">The progress reporter. The call is ignored when null.</param>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+            <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
         </member>
         <member name="T:Notification.Core.SlowedProgress`1">
             <summary>

--- a/src/Notification.Core/Notification.Core.xml
+++ b/src/Notification.Core/Notification.Core.xml
@@ -284,6 +284,9 @@
         <member name="F:Notification.Core.NotificationBuilder._onClose">
             <summary>The action invoked when the notification is closed.</summary>
         </member>
+        <member name="F:Notification.Core.NotificationBuilder._onRightClick">
+            <summary>The action invoked when the notification is right-clicked.</summary>
+        </member>
         <member name="F:Notification.Core.NotificationBuilder._icon">
             <summary>The notification icon.</summary>
         </member>
@@ -495,6 +498,13 @@
             Sets the action invoked when the notification is closed.
             </summary>
             <param name="onClose">The close action.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.OnRightClick(System.Action)">
+            <summary>
+            Sets the action invoked when the notification body is right-clicked.
+            </summary>
+            <param name="onRightClick">The right-click action.</param>
             <returns>The current builder instance for chaining.</returns>
         </member>
         <member name="M:Notification.Core.NotificationBuilder.WithIcon(System.Object)">
@@ -1733,6 +1743,11 @@
         <member name="P:Notification.Core.NotificationRequest.OnClose">
             <summary>
             Gets or sets the action invoked when the notification is closed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.OnRightClick">
+            <summary>
+            Gets or sets the action invoked when the notification body is right-clicked.
             </summary>
         </member>
         <member name="P:Notification.Core.NotificationRequest.Icon">

--- a/src/Notification.Core/Notification.Core.xml
+++ b/src/Notification.Core/Notification.Core.xml
@@ -4,5 +4,1952 @@
         <name>Notification.Core</name>
     </assembly>
     <members>
+        <member name="T:Notification.Core.AbsolutePositionData">
+            <summary>
+            Represents absolute position data for placing a notification at specific screen coordinates relative to a corner.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.AbsolutePositionData.X">
+            <summary>Gets or sets the horizontal offset in pixels from the base corner.</summary>
+        </member>
+        <member name="P:Notification.Core.AbsolutePositionData.Y">
+            <summary>Gets or sets the vertical offset in pixels from the base corner.</summary>
+        </member>
+        <member name="P:Notification.Core.AbsolutePositionData.BaseCorner">
+            <summary>Gets or sets the screen corner used as the origin for positioning.</summary>
+        </member>
+        <member name="T:Notification.Core.NotificationColor">
+            <summary>
+            Represents a platform-independent RGBA color for notification styling.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationColor.R">
+            <summary>Gets the red component of the color (0–255).</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationColor.G">
+            <summary>Gets the green component of the color (0–255).</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationColor.B">
+            <summary>Gets the blue component of the color (0–255).</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationColor.A">
+            <summary>Gets the alpha (opacity) component of the color (0–255).</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.#ctor(System.Byte,System.Byte,System.Byte,System.Byte)">
+            <summary>
+            Initializes a new <see cref="T:Notification.Core.NotificationColor"/> with the specified RGBA components.
+            </summary>
+            <param name="r">The red component (0–255).</param>
+            <param name="g">The green component (0–255).</param>
+            <param name="b">The blue component (0–255).</param>
+            <param name="a">The alpha component (0–255). Defaults to 255 (fully opaque).</param>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.FromRgb(System.Byte,System.Byte,System.Byte)">
+            <summary>
+            Creates a fully opaque color from the specified RGB components.
+            </summary>
+            <param name="r">The red component (0–255).</param>
+            <param name="g">The green component (0–255).</param>
+            <param name="b">The blue component (0–255).</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationColor"/> with alpha set to 255.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.FromArgb(System.Byte,System.Byte,System.Byte,System.Byte)">
+            <summary>
+            Creates a color from the specified ARGB components.
+            </summary>
+            <param name="a">The alpha component (0–255).</param>
+            <param name="r">The red component (0–255).</param>
+            <param name="g">The green component (0–255).</param>
+            <param name="b">The blue component (0–255).</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationColor"/> instance.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.FromHex(System.String)">
+            <summary>
+            Parses a hexadecimal color string in #RRGGBB or #AARRGGBB format.
+            </summary>
+            <param name="hex">The hex color string, with or without a leading '#'.</param>
+            <returns>A new <see cref="T:Notification.Core.NotificationColor"/> parsed from the hex string.</returns>
+            <exception cref="T:System.ArgumentNullException">Thrown when <paramref name="hex"/> is null or whitespace.</exception>
+            <exception cref="T:System.FormatException">Thrown when the hex string is not in a valid format.</exception>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.ToHex">
+            <summary>
+            Converts this color to its #AARRGGBB hexadecimal string representation.
+            </summary>
+            <returns>A hex string in the format #AARRGGBB.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.op_Implicit(System.String)~Notification.Core.NotificationColor">
+            <summary>
+            Implicitly converts a hex color string to a <see cref="T:Notification.Core.NotificationColor"/>.
+            </summary>
+            <param name="hex">The hex color string to convert.</param>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.White">
+            <summary>Represents the color white (255, 255, 255).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.WhiteSmoke">
+            <summary>Represents the color white smoke (245, 245, 245).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.LimeGreen">
+            <summary>Represents the color lime green (50, 205, 50).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.Orange">
+            <summary>Represents the color orange (255, 165, 0).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.OrangeRed">
+            <summary>Represents the color orange red (255, 69, 0).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.CornflowerBlue">
+            <summary>Represents the color cornflower blue (100, 149, 237).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.DarkGray">
+            <summary>Represents the color dark gray (68, 68, 68).</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationColor.Green">
+            <summary>Represents the color green (1, 211, 40).</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.Equals(Notification.Core.NotificationColor)">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationColor.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationColor.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationColor.op_Equality(Notification.Core.NotificationColor,Notification.Core.NotificationColor)">
+            <summary>Determines whether two <see cref="T:Notification.Core.NotificationColor"/> instances are equal.</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.op_Inequality(Notification.Core.NotificationColor,Notification.Core.NotificationColor)">
+            <summary>Determines whether two <see cref="T:Notification.Core.NotificationColor"/> instances are not equal.</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationColor.ToString">
+            <inheritdoc />
+        </member>
+        <member name="T:Notification.Core.NotificationImageData">
+            <summary>
+            Represents image data and layout settings for a notification image.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationImageData.RawData">
+            <summary>Gets or sets the raw image bytes. Used when the image is provided as in-memory data.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationImageData.Uri">
+            <summary>Gets or sets the URI of the image resource. Used when the image is loaded from a file or URL.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationImageData.Position">
+            <summary>Gets or sets the position of the image within the notification layout.</summary>
+        </member>
+        <member name="T:Notification.Core.NotificationTextSettings">
+            <summary>
+            Represents text rendering settings for notification content, including font, alignment, and opacity.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.FontFamily">
+            <summary>Gets or sets the font family name. Defaults to "Segoe UI".</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.FontSize">
+            <summary>Gets or sets the font size in device-independent pixels. Defaults to 14.0.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.FontStyle">
+            <summary>Gets or sets the font style (e.g., Normal, Italic). Defaults to <see cref="F:Notification.Core.NotificationFontStyle.Normal"/>.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.FontWeight">
+            <summary>Gets or sets the font weight (e.g., Normal, Bold). Defaults to <see cref="F:Notification.Core.NotificationFontWeight.Normal"/>.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.TextAlignment">
+            <summary>Gets or sets the text alignment within the text block. Defaults to <see cref="F:Notification.Core.NotificationTextAlignment.Left"/>.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.HorizontalAlignment">
+            <summary>Gets or sets the horizontal alignment of the text element. Defaults to <see cref="F:Notification.Core.NotificationHorizontalAlignment.Stretch"/>.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.VerticalAlignment">
+            <summary>Gets or sets the vertical alignment of the text element. Defaults to <see cref="F:Notification.Core.NotificationVerticalAlignment.Stretch"/>.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationTextSettings.Opacity">
+            <summary>Gets or sets the text opacity, where 0.0 is fully transparent and 1.0 is fully opaque. Defaults to 1.0.</summary>
+        </member>
+        <member name="T:Notification.Core.NotificationThickness">
+            <summary>
+            Represents a platform-independent thickness (margin or padding) with values for each side.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationThickness.Left">
+            <summary>Gets the left side thickness in device-independent pixels.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationThickness.Top">
+            <summary>Gets the top side thickness in device-independent pixels.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationThickness.Right">
+            <summary>Gets the right side thickness in device-independent pixels.</summary>
+        </member>
+        <member name="P:Notification.Core.NotificationThickness.Bottom">
+            <summary>Gets the bottom side thickness in device-independent pixels.</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.#ctor(System.Double)">
+            <summary>
+            Initializes a new <see cref="T:Notification.Core.NotificationThickness"/> with the same value applied to all four sides.
+            </summary>
+            <param name="uniform">The uniform thickness value for all sides.</param>
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.#ctor(System.Double,System.Double,System.Double,System.Double)">
+            <summary>
+            Initializes a new <see cref="T:Notification.Core.NotificationThickness"/> with individual values for each side.
+            </summary>
+            <param name="left">The left side thickness.</param>
+            <param name="top">The top side thickness.</param>
+            <param name="right">The right side thickness.</param>
+            <param name="bottom">The bottom side thickness.</param>
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.Equals(Notification.Core.NotificationThickness)">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.Equals(System.Object)">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.GetHashCode">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.op_Equality(Notification.Core.NotificationThickness,Notification.Core.NotificationThickness)">
+            <summary>Determines whether two <see cref="T:Notification.Core.NotificationThickness"/> instances are equal.</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationThickness.op_Inequality(Notification.Core.NotificationThickness,Notification.Core.NotificationThickness)">
+            <summary>Determines whether two <see cref="T:Notification.Core.NotificationThickness"/> instances are not equal.</summary>
+        </member>
+        <member name="T:Notification.Core.NotificationBuilder">
+            <summary>
+            Provides a fluent API for constructing <see cref="T:Notification.Core.NotificationRequest"/> instances.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._title">
+            <summary>The notification title.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._message">
+            <summary>The notification message body.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._type">
+            <summary>The notification type.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._areaName">
+            <summary>The name of the target notification area.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._expirationTime">
+            <summary>The time after which the notification expires; <c>null</c> means never.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._closeOnClick">
+            <summary>Indicates whether the notification closes when clicked.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._showCloseButton">
+            <summary>Indicates whether the close button is shown.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._priority">
+            <summary>The notification priority.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._groupKey">
+            <summary>The grouping key used to coalesce related notifications.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._backgroundColor">
+            <summary>The background color override.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._foregroundColor">
+            <summary>The foreground color override.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._titleSettings">
+            <summary>The text settings applied to the title.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._messageSettings">
+            <summary>The text settings applied to the message.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._trimType">
+            <summary>The text trimming mode.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._rowsCount">
+            <summary>The maximum number of message rows before trimming applies.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._leftButtonAction">
+            <summary>The action invoked when the left button is clicked.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._leftButtonContent">
+            <summary>The content (text) of the left button.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._rightButtonAction">
+            <summary>The action invoked when the right button is clicked.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._rightButtonContent">
+            <summary>The content (text) of the right button.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._onClick">
+            <summary>The action invoked when the notification is clicked.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._onClose">
+            <summary>The action invoked when the notification is closed.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._icon">
+            <summary>The notification icon.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._platformImage">
+            <summary>The platform-specific image object.</summary>
+        </member>
+        <member name="F:Notification.Core.NotificationBuilder._extensions">
+            <summary>The collection of platform-specific extension values.</summary>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.Create">
+            <summary>
+            Creates a new empty <see cref="T:Notification.Core.NotificationBuilder"/> instance.
+            </summary>
+            <returns>A new builder instance.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.Create(System.String,System.String)">
+            <summary>
+            Creates a new <see cref="T:Notification.Core.NotificationBuilder"/> instance with the specified title and message.
+            </summary>
+            <param name="title">The notification title.</param>
+            <param name="message">The notification message.</param>
+            <returns>A new builder instance with title and message set.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithTitle(System.String)">
+            <summary>
+            Sets the notification title.
+            </summary>
+            <param name="title">The title text.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithMessage(System.String)">
+            <summary>
+            Sets the notification message.
+            </summary>
+            <param name="message">The message text.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.OfType(Notification.Core.NotificationType)">
+            <summary>
+            Sets the notification type.
+            </summary>
+            <param name="type">The notification type.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.AsInformation">
+            <summary>
+            Sets the notification type to <see cref="F:Notification.Core.NotificationType.Information"/>.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.AsSuccess">
+            <summary>
+            Sets the notification type to <see cref="F:Notification.Core.NotificationType.Success"/>.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.AsWarning">
+            <summary>
+            Sets the notification type to <see cref="F:Notification.Core.NotificationType.Warning"/>.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.AsError">
+            <summary>
+            Sets the notification type to <see cref="F:Notification.Core.NotificationType.Error"/>.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.InArea(System.String)">
+            <summary>
+            Sets the notification area name where the notification will be displayed.
+            </summary>
+            <param name="areaName">The target area name.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.ExpiresIn(System.TimeSpan)">
+            <summary>
+            Sets the notification expiration time.
+            </summary>
+            <param name="time">The duration after which the notification automatically closes.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.ExpiresInSeconds(System.Double)">
+            <summary>
+            Sets the notification expiration time in seconds.
+            </summary>
+            <param name="seconds">The number of seconds before the notification closes.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.NeverExpires">
+            <summary>
+            Configures the notification to never expire automatically.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.CloseOnClick(System.Boolean)">
+            <summary>
+            Sets whether the notification closes when clicked.
+            </summary>
+            <param name="close">True to close on click; false to keep open.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.HideCloseButton">
+            <summary>
+            Hides the close button on the notification.
+            </summary>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithPriority(Notification.Core.NotificationPriority)">
+            <summary>
+            Sets the notification display priority.
+            </summary>
+            <param name="priority">The priority level.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.GroupAs(System.String)">
+            <summary>
+            Sets the group key for notification deduplication.
+            </summary>
+            <param name="groupKey">The group key. Notifications with the same key replace each other.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithBackground(Notification.Core.NotificationColor)">
+            <summary>
+            Sets the notification background color.
+            </summary>
+            <param name="color">The background color.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithBackground(System.String)">
+            <summary>
+            Sets the notification background color from a hex string.
+            </summary>
+            <param name="hex">The hex color string (e.g., "#FF0000").</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithForeground(Notification.Core.NotificationColor)">
+            <summary>
+            Sets the notification foreground (text) color.
+            </summary>
+            <param name="color">The foreground color.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithForeground(System.String)">
+            <summary>
+            Sets the notification foreground (text) color from a hex string.
+            </summary>
+            <param name="hex">The hex color string (e.g., "#FFFFFF").</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithTitleSettings(System.Action{Notification.Core.NotificationTextSettings})">
+            <summary>
+            Configures the title text rendering settings.
+            </summary>
+            <param name="configure">An action to configure the title text settings.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithMessageSettings(System.Action{Notification.Core.NotificationTextSettings})">
+            <summary>
+            Configures the message text rendering settings.
+            </summary>
+            <param name="configure">An action to configure the message text settings.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithTrimming(Notification.Core.NotificationTextTrimType,System.UInt32)">
+            <summary>
+            Configures text trimming behavior for the notification message.
+            </summary>
+            <param name="trimType">The text trimming type.</param>
+            <param name="rows">The maximum number of visible rows before trimming.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithLeftButton(System.String,System.Action)">
+            <summary>
+            Configures the left button with text and a click action.
+            </summary>
+            <param name="text">The button label text.</param>
+            <param name="action">The action invoked when the button is clicked.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithRightButton(System.String,System.Action)">
+            <summary>
+            Configures the right button with text and a click action.
+            </summary>
+            <param name="text">The button label text.</param>
+            <param name="action">The action invoked when the button is clicked.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithOkCancel(System.Action,System.Action)">
+            <summary>
+            Configures Ok and Cancel buttons with the specified actions.
+            </summary>
+            <param name="onOk">The action invoked when Ok is clicked.</param>
+            <param name="onCancel">The action invoked when Cancel is clicked. If null, a no-op action is used.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.OnClick(System.Action)">
+            <summary>
+            Sets the action invoked when the notification body is clicked.
+            </summary>
+            <param name="onClick">The click action.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.OnClose(System.Action)">
+            <summary>
+            Sets the action invoked when the notification is closed.
+            </summary>
+            <param name="onClose">The close action.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithIcon(System.Object)">
+            <summary>
+            Sets the notification icon. The type is platform-dependent.
+            </summary>
+            <param name="icon">The icon object.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithImage(Notification.Core.NotificationImageData)">
+            <summary>
+            Sets the notification image.
+            </summary>
+            <param name="image">The image data to display in the notification.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.WithExtension(System.String,System.Object)">
+            <summary>
+            Adds a custom extension key-value pair to the notification.
+            </summary>
+            <param name="key">The extension key.</param>
+            <param name="value">The extension value.</param>
+            <returns>The current builder instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Core.NotificationBuilder.Build">
+            <summary>
+            Builds and returns the configured <see cref="T:Notification.Core.NotificationRequest"/> instance.
+            </summary>
+            <returns>A new <see cref="T:Notification.Core.NotificationRequest"/> populated with the builder's settings.</returns>
+        </member>
+        <member name="T:Notification.Core.NotificationServiceExtensions">
+            <summary>
+            Provides extension methods for <see cref="T:Notification.Core.INotificationService"/> to simplify notification creation.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationServiceExtensions.Show(Notification.Core.INotificationService,System.Action{Notification.Core.NotificationBuilder})">
+            <summary>
+            Shows a notification configured via a fluent builder action.
+            </summary>
+            <param name="service">The notification service instance.</param>
+            <param name="configure">An action that configures the notification using a <see cref="T:Notification.Core.NotificationBuilder"/>.</param>
+            <returns>The unique identifier of the displayed notification.</returns>
+        </member>
+        <member name="T:Notification.Core.NotificationConfiguration">
+            <summary>
+            Provides default configuration settings for the notification system, including positioning, sizing, colors, and text formatting.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MessagePosition">
+            <summary>
+            Gets or sets the screen position where notifications are displayed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.IsReversedPanel">
+            <summary>
+            Gets or sets a value indicating whether the notification panel order is reversed. When null, the default behavior is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MinWidth">
+            <summary>
+            Gets or sets the minimum width of a notification in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MaxWidth">
+            <summary>
+            Gets or sets the maximum width of a notification in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MaxOverlayWindowCount">
+            <summary>
+            Gets or sets the maximum number of notification overlay windows that can be displayed simultaneously.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.CollapseProgressIfMoreRows">
+            <summary>
+            Gets or sets a value indicating whether progress bars are automatically collapsed when there are more rows than the limit.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultExpirationTime">
+            <summary>
+            Gets or sets the default expiration time for notifications that do not specify one explicitly.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultBackgroundColor">
+            <summary>
+            Gets or sets the default background color for notifications without a specific type.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultForegroundColor">
+            <summary>
+            Gets or sets the default foreground (text) color for notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.SuccessBackgroundColor">
+            <summary>
+            Gets or sets the background color for success notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.WarningBackgroundColor">
+            <summary>
+            Gets or sets the background color for warning notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.ErrorBackgroundColor">
+            <summary>
+            Gets or sets the background color for error notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.InformationBackgroundColor">
+            <summary>
+            Gets or sets the background color for information notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultProgressColor">
+            <summary>
+            Gets or sets the default color for progress bar indicators.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.BaseTextSize">
+            <summary>
+            Gets or sets the base text size in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.TitleSize">
+            <summary>
+            Gets or sets the title text size in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MessageSize">
+            <summary>
+            Gets or sets the message text size in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.FontName">
+            <summary>
+            Gets or sets the font family name used for notification text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.TitleTextAlignment">
+            <summary>
+            Gets or sets the text alignment for notification titles.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.MessageTextAlignment">
+            <summary>
+            Gets or sets the text alignment for notification messages.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultRowCount">
+            <summary>
+            Gets or sets the default number of visible text rows before trimming.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultTrimType">
+            <summary>
+            Gets or sets the default text trimming type applied to notification text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.CancellationMessage">
+            <summary>
+            Gets or sets the message displayed when an operation is cancelled.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.OpenFileMessage">
+            <summary>
+            Gets or sets the label text for the "Open File" action.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.OpenFolderMessage">
+            <summary>
+            Gets or sets the label text for the "Open Folder" action.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultLeftButtonContent">
+            <summary>
+            Gets or sets the default content for the left button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultRightButtonContent">
+            <summary>
+            Gets or sets the default content for the right button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultProgressButtonContent">
+            <summary>
+            Gets or sets the default content for the progress bar cancel button.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationCoreServiceCollectionExtensions">
+            <summary>
+            Provides extension methods for registering core notification services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationCoreServiceCollectionExtensions.AddNotifications(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the core notification services including configuration, event service, and notification queue.
+            </summary>
+            <param name="services">The service collection to add the services to.</param>
+            <param name="configure">An optional action to customize the notification configuration.</param>
+            <returns>The service collection for chaining.</returns>
+        </member>
+        <member name="T:Notification.Core.Corner">
+            <summary>
+            Specifies a corner of a rectangular area.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.Corner.TopLeft">
+            <summary>
+            The top-left corner.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.Corner.TopRight">
+            <summary>
+            The top-right corner.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.Corner.BottomLeft">
+            <summary>
+            The bottom-left corner.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.Corner.BottomRight">
+            <summary>
+            The bottom-right corner.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.ImagePosition">
+            <summary>
+            Specifies the position of an image within a notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.ImagePosition.None">
+            <summary>
+            No image is displayed.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.ImagePosition.Top">
+            <summary>
+            The image is placed at the top of the notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.ImagePosition.Bottom">
+            <summary>
+            The image is placed at the bottom of the notification.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationFontStyle">
+            <summary>
+            Specifies the font style for notification text.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontStyle.Normal">
+            <summary>
+            Normal upright font style.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontStyle.Italic">
+            <summary>
+            Italic font style with characters designed to slant to the right.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontStyle.Oblique">
+            <summary>
+            Oblique font style with artificially slanted characters.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationFontWeight">
+            <summary>
+            Specifies the weight (thickness) of the font used in notification text.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Thin">
+            <summary>
+            Thin font weight (100).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.ExtraLight">
+            <summary>
+            Extra-light font weight (200).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Light">
+            <summary>
+            Light font weight (300).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Normal">
+            <summary>
+            Normal (regular) font weight (400).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Medium">
+            <summary>
+            Medium font weight (500).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.SemiBold">
+            <summary>
+            Semi-bold font weight (600).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Bold">
+            <summary>
+            Bold font weight (700).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.ExtraBold">
+            <summary>
+            Extra-bold font weight (800).
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationFontWeight.Black">
+            <summary>
+            Black (heavy) font weight (900).
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationHorizontalAlignment">
+            <summary>
+            Specifies the horizontal alignment of content within a notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationHorizontalAlignment.Left">
+            <summary>
+            Content is aligned to the left.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationHorizontalAlignment.Center">
+            <summary>
+            Content is centered horizontally.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationHorizontalAlignment.Right">
+            <summary>
+            Content is aligned to the right.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationHorizontalAlignment.Stretch">
+            <summary>
+            Content is stretched to fill the available horizontal space.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationLifecycleStage">
+            <summary>
+            Represents the lifecycle stage of a notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationLifecycleStage.Shown">
+            <summary>
+            The notification has been displayed to the user.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationLifecycleStage.Clicked">
+            <summary>
+            The notification was clicked by the user.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationLifecycleStage.Closed">
+            <summary>
+            The notification was explicitly closed.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationLifecycleStage.TimedOut">
+            <summary>
+            The notification expired after its display duration elapsed.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationLifecycleStage.Dismissed">
+            <summary>
+            The notification was dismissed by the user.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationPosition">
+            <summary>
+            Specifies the screen position where notifications are displayed.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.TopLeft">
+            <summary>
+            Top-left corner of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.TopRight">
+            <summary>
+            Top-right corner of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.TopCenter">
+            <summary>
+            Top-center of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.BottomLeft">
+            <summary>
+            Bottom-left corner of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.BottomRight">
+            <summary>
+            Bottom-right corner of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.BottomCenter">
+            <summary>
+            Bottom-center of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.CenterLeft">
+            <summary>
+            Center-left edge of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.CenterRight">
+            <summary>
+            Center-right edge of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.Center">
+            <summary>
+            Center of the screen.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPosition.Absolute">
+            <summary>
+            An absolute position specified by explicit coordinates.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationPriority">
+            <summary>
+            Specifies the priority level of a notification, affecting its display order.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPriority.Low">
+            <summary>
+            Low priority; displayed after higher-priority notifications.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPriority.Normal">
+            <summary>
+            Normal (default) priority.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPriority.High">
+            <summary>
+            High priority; displayed before normal and low-priority notifications.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationPriority.Critical">
+            <summary>
+            Critical priority; displayed immediately above all other notifications.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationTextAlignment">
+            <summary>
+            Specifies the horizontal text alignment within a notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextAlignment.Left">
+            <summary>
+            Text is aligned to the left edge.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextAlignment.Center">
+            <summary>
+            Text is centered horizontally.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextAlignment.Right">
+            <summary>
+            Text is aligned to the right edge.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextAlignment.Justify">
+            <summary>
+            Text is justified, stretching to fill the available width.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationTextTrimType">
+            <summary>
+            Specifies how notification text is trimmed when it exceeds the available space.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextTrimType.NoTrim">
+            <summary>
+            No trimming is applied; text is displayed in full.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextTrimType.Trim">
+            <summary>
+            Text is trimmed with an ellipsis when it exceeds the available space.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextTrimType.Attach">
+            <summary>
+            A "more" link or indicator is attached to the trimmed text.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationTextTrimType.AttachIfMoreRows">
+            <summary>
+            A "more" link or indicator is attached only when the text exceeds the maximum number of rows.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationType">
+            <summary>
+            Specifies the type of a notification, which determines its visual appearance and semantics.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.None">
+            <summary>
+            No specific type; uses default styling.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.Information">
+            <summary>
+            An informational notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.Success">
+            <summary>
+            A success notification indicating a completed operation.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.Warning">
+            <summary>
+            A warning notification indicating a potential issue.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.Error">
+            <summary>
+            An error notification indicating a failure or critical issue.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationType.Notification">
+            <summary>
+            A general-purpose notification.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationVerticalAlignment">
+            <summary>
+            Specifies the vertical alignment of content within a notification.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationVerticalAlignment.Top">
+            <summary>
+            Content is aligned to the top.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationVerticalAlignment.Center">
+            <summary>
+            Content is centered vertically.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationVerticalAlignment.Bottom">
+            <summary>
+            Content is aligned to the bottom.
+            </summary>
+        </member>
+        <member name="F:Notification.Core.NotificationVerticalAlignment.Stretch">
+            <summary>
+            Content is stretched to fill the available vertical space.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.INotificationEventService">
+            <summary>
+            Provides events for tracking notification lifecycle changes.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.INotificationEventService.NotificationLifecycleChanged">
+            <summary>
+            Occurs when any notification lifecycle stage changes.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.INotificationEventService.NotificationShown">
+            <summary>
+            Occurs when a notification is displayed to the user.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.INotificationEventService.NotificationClosed">
+            <summary>
+            Occurs when a notification is closed or dismissed.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.INotificationEventService.NotificationClicked">
+            <summary>
+            Occurs when a notification is clicked by the user.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.INotificationEventService.Raise(Notification.Core.NotificationLifecycleEventArgs)">
+            <summary>
+            Raises a notification lifecycle event.
+            </summary>
+            <param name="args">The event arguments containing the notification identifier and lifecycle stage.</param>
+        </member>
+        <member name="T:Notification.Core.NotificationEventService">
+            <summary>
+            Provides a centralized service for raising and subscribing to notification lifecycle events.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.NotificationEventService.NotificationLifecycleChanged">
+            <summary>
+            Occurs when any notification lifecycle stage changes.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.NotificationEventService.NotificationShown">
+            <summary>
+            Occurs when a notification is displayed to the user.
+            </summary>
+        </member>
+        <member name="E:Notification.Core.NotificationEventService.NotificationClosed">
+            <summary>
+            Occurs when a notification is closed for any reason (explicit close, timeout, or dismissal).
+            </summary>
+        </member>
+        <member name="E:Notification.Core.NotificationEventService.NotificationClicked">
+            <summary>
+            Occurs when a notification is clicked by the user.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationEventService.Raise(Notification.Core.NotificationLifecycleEventArgs)">
+            <summary>
+            Raises the appropriate lifecycle events based on the notification stage.
+            </summary>
+            <param name="args">The event arguments containing notification details and the lifecycle stage.</param>
+        </member>
+        <member name="T:Notification.Core.NotificationLifecycleEventArgs">
+            <summary>
+            Provides event data for notification lifecycle events such as shown, clicked, closed, and dismissed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationLifecycleEventArgs.NotificationId">
+            <summary>
+            Gets the unique identifier of the notification that triggered this event.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationLifecycleEventArgs.Stage">
+            <summary>
+            Gets the lifecycle stage that the notification has entered.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationLifecycleEventArgs.Timestamp">
+            <summary>
+            Gets the UTC timestamp when this lifecycle event occurred.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationLifecycleEventArgs.Title">
+            <summary>
+            Gets the title of the notification at the time of the event.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationLifecycleEventArgs.Message">
+            <summary>
+            Gets the message of the notification at the time of the event.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationLifecycleEventArgs.#ctor(System.Guid,Notification.Core.NotificationLifecycleStage,System.String,System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.NotificationLifecycleEventArgs"/> class.
+            </summary>
+            <param name="notificationId">The unique identifier of the notification.</param>
+            <param name="stage">The lifecycle stage that the notification has entered.</param>
+            <param name="title">The notification title.</param>
+            <param name="message">The notification message.</param>
+        </member>
+        <member name="T:Notification.Core.INotificationConfiguration">
+            <summary>
+            Provides configuration options for the notification system appearance and behavior.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MessagePosition">
+            <summary>
+            Gets or sets the position on screen where notifications are displayed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.IsReversedPanel">
+            <summary>
+            Gets or sets whether the notification panel stacking order is reversed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MinWidth">
+            <summary>
+            Gets or sets the minimum width of the notification window in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MaxWidth">
+            <summary>
+            Gets or sets the maximum width of the notification window in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MaxOverlayWindowCount">
+            <summary>
+            Gets or sets the maximum number of overlay notification windows displayed simultaneously.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.CollapseProgressIfMoreRows">
+            <summary>
+            Gets or sets whether to collapse progress notifications when more rows are displayed than allowed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultExpirationTime">
+            <summary>
+            Gets or sets the default time after which a notification automatically expires.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultBackgroundColor">
+            <summary>
+            Gets or sets the default background color for notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultForegroundColor">
+            <summary>
+            Gets or sets the default foreground (text) color for notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.SuccessBackgroundColor">
+            <summary>
+            Gets or sets the background color for success notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.WarningBackgroundColor">
+            <summary>
+            Gets or sets the background color for warning notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.ErrorBackgroundColor">
+            <summary>
+            Gets or sets the background color for error notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.InformationBackgroundColor">
+            <summary>
+            Gets or sets the background color for informational notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultProgressColor">
+            <summary>
+            Gets or sets the default color for progress indicators.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.BaseTextSize">
+            <summary>
+            Gets or sets the base text size in pixels used as a reference for scaling.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.TitleSize">
+            <summary>
+            Gets or sets the font size for notification titles in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MessageSize">
+            <summary>
+            Gets or sets the font size for notification messages in pixels.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.FontName">
+            <summary>
+            Gets or sets the font family name used for notification text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.TitleTextAlignment">
+            <summary>
+            Gets or sets the text alignment for notification titles.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.MessageTextAlignment">
+            <summary>
+            Gets or sets the text alignment for notification messages.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultRowCount">
+            <summary>
+            Gets or sets the default number of visible text rows in a notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultTrimType">
+            <summary>
+            Gets or sets the default text trimming type when content exceeds available space.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.CancellationMessage">
+            <summary>
+            Gets or sets the display text for the cancellation action.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.OpenFileMessage">
+            <summary>
+            Gets or sets the display text for the open file action.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.OpenFolderMessage">
+            <summary>
+            Gets or sets the display text for the open folder action.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultLeftButtonContent">
+            <summary>
+            Gets or sets the default content displayed on the left button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultRightButtonContent">
+            <summary>
+            Gets or sets the default content displayed on the right button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultProgressButtonContent">
+            <summary>
+            Gets or sets the default content displayed on the progress action button.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.INotificationContent">
+            <summary>
+            Represents the content and visual configuration of a notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.Title">
+            <summary>
+            Gets the title text displayed at the top of the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.Message">
+            <summary>
+            Gets the message body text of the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.Type">
+            <summary>
+            Gets the type of the notification (e.g., success, warning, error, information).
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.BackgroundColor">
+            <summary>
+            Gets the custom background color override for the notification, or <c>null</c> to use the default.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.ForegroundColor">
+            <summary>
+            Gets the custom foreground color override for the notification, or <c>null</c> to use the default.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.TrimType">
+            <summary>
+            Gets the text trimming type applied when content exceeds available space.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.RowsCount">
+            <summary>
+            Gets the maximum number of visible text rows in the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.TitleSettings">
+            <summary>
+            Gets the text display settings for the notification title.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.MessageSettings">
+            <summary>
+            Gets the text display settings for the notification message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.Icon">
+            <summary>
+            Gets the icon displayed in the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.Image">
+            <summary>
+            Gets the image data displayed in the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.LeftButtonAction">
+            <summary>
+            Gets the action invoked when the left button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.LeftButtonContent">
+            <summary>
+            Gets the content displayed on the left button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.RightButtonAction">
+            <summary>
+            Gets the action invoked when the right button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.RightButtonContent">
+            <summary>
+            Gets the content displayed on the right button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationContent.CloseOnClick">
+            <summary>
+            Gets a value indicating whether the notification is dismissed when clicked.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.INotificationService">
+            <summary>
+            Provides methods for displaying and managing notifications.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.INotificationService.Show(Notification.Core.NotificationRequest)">
+            <summary>
+            Displays a notification based on the specified request.
+            </summary>
+            <param name="request">The notification request containing content and configuration.</param>
+            <returns>A unique identifier for the displayed notification.</returns>
+        </member>
+        <member name="M:Notification.Core.INotificationService.Dismiss(System.Guid)">
+            <summary>
+            Dismisses a specific notification by its identifier.
+            </summary>
+            <param name="notificationId">The unique identifier of the notification to dismiss.</param>
+        </member>
+        <member name="M:Notification.Core.INotificationService.DismissAll">
+            <summary>
+            Dismisses all currently displayed notifications.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.INotifierProgress">
+            <summary>
+            Represents a progress reporter for notification-based operations with cancellation and timing support.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotifierProgress.IsFinished">
+            <summary>
+            Gets a value indicating whether the associated operation has finished.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotifierProgress.CancellationToken">
+            <summary>
+            Gets the cancellation token that signals when the operation should be cancelled.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotifierProgress.CancelSource">
+            <summary>
+            Gets the cancellation token source used to trigger cancellation of the operation.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotifierProgress.WaitingTimer">
+            <summary>
+            Gets the timer that tracks the elapsed waiting time of the operation.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationContentData">
+            <summary>
+            Represents the content data for a notification, including text, colors, buttons, and media.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.Title">
+            <summary>
+            Gets or sets the notification title text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.Message">
+            <summary>
+            Gets or sets the notification message body text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.Type">
+            <summary>
+            Gets or sets the notification type that determines the visual style.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.BackgroundColor">
+            <summary>
+            Gets or sets the custom background color. When null, the default color from configuration is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.ForegroundColor">
+            <summary>
+            Gets or sets the custom foreground (text) color. When null, the default color from configuration is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.TrimType">
+            <summary>
+            Gets or sets the text trimming type applied to the notification message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.RowsCount">
+            <summary>
+            Gets or sets the maximum number of visible text rows before trimming is applied.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.TitleSettings">
+            <summary>
+            Gets or sets the text rendering settings for the title.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.MessageSettings">
+            <summary>
+            Gets or sets the text rendering settings for the message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.Icon">
+            <summary>
+            Gets or sets the icon displayed in the notification. The type is platform-dependent.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.Image">
+            <summary>
+            Gets or sets the image data displayed in the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.LeftButtonAction">
+            <summary>
+            Gets or sets the action invoked when the left button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.LeftButtonContent">
+            <summary>
+            Gets or sets the content displayed on the left button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.RightButtonAction">
+            <summary>
+            Gets or sets the action invoked when the right button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.RightButtonContent">
+            <summary>
+            Gets or sets the content displayed on the right button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationContentData.CloseOnClick">
+            <summary>
+            Gets or sets a value indicating whether the notification is closed when clicked.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationProgressReport">
+            <summary>
+            Represents an immutable progress report for a notification progress bar.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationProgressReport.Value">
+            <summary>
+            Gets the progress value as a percentage (0-100), or null if indeterminate.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationProgressReport.Message">
+            <summary>
+            Gets the progress status message displayed to the user.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationProgressReport.Title">
+            <summary>
+            Gets the progress bar title text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationProgressReport.ShowCancel">
+            <summary>
+            Gets a value indicating whether the cancel button should be shown, or null to keep the current state.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationProgressReport.#ctor(System.Nullable{System.Double},System.String,System.String,System.Nullable{System.Boolean})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.NotificationProgressReport"/> struct.
+            </summary>
+            <param name="value">The progress value as a percentage (0-100), or null for indeterminate.</param>
+            <param name="message">The progress status message.</param>
+            <param name="title">The progress bar title.</param>
+            <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        </member>
+        <member name="T:Notification.Core.NotificationRequest">
+            <summary>
+            Represents a complete request to display a notification, including all visual and behavioral options.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Id">
+            <summary>
+            Gets or sets the unique identifier for this notification request.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Title">
+            <summary>
+            Gets or sets the notification title text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Message">
+            <summary>
+            Gets or sets the notification message body text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Type">
+            <summary>
+            Gets or sets the notification type that determines the visual style.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.AreaName">
+            <summary>
+            Gets or sets the name of the notification area where this notification should be displayed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.ExpirationTime">
+            <summary>
+            Gets or sets the duration after which the notification automatically closes. When null, the default expiration time from configuration is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.CloseOnClick">
+            <summary>
+            Gets or sets a value indicating whether the notification is closed when clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.ShowCloseButton">
+            <summary>
+            Gets or sets a value indicating whether the close button is visible.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Priority">
+            <summary>
+            Gets or sets the display priority of this notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.GroupKey">
+            <summary>
+            Gets or sets the group key used to deduplicate notifications. Notifications with the same group key replace each other.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.BackgroundColor">
+            <summary>
+            Gets or sets the custom background color. When null, the default color from configuration is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.ForegroundColor">
+            <summary>
+            Gets or sets the custom foreground (text) color. When null, the default color from configuration is used.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.TitleSettings">
+            <summary>
+            Gets or sets the text rendering settings for the title.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.MessageSettings">
+            <summary>
+            Gets or sets the text rendering settings for the message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.TrimType">
+            <summary>
+            Gets or sets the text trimming type applied to the notification message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.RowsCount">
+            <summary>
+            Gets or sets the maximum number of visible text rows before trimming is applied.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.LeftButtonAction">
+            <summary>
+            Gets or sets the action invoked when the left button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.LeftButtonContent">
+            <summary>
+            Gets or sets the text content displayed on the left button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.RightButtonAction">
+            <summary>
+            Gets or sets the action invoked when the right button is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.RightButtonContent">
+            <summary>
+            Gets or sets the text content displayed on the right button.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.OnClick">
+            <summary>
+            Gets or sets the action invoked when the notification body is clicked.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.OnClose">
+            <summary>
+            Gets or sets the action invoked when the notification is closed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Icon">
+            <summary>
+            Gets or sets the icon displayed in the notification. The type is platform-dependent.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.PlatformImage">
+            <summary>
+            Gets or sets the platform-specific image object for the notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.Extensions">
+            <summary>
+            Gets or sets a dictionary of custom extension data attached to this notification.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.ProgressBarOptions">
+            <summary>
+            Represents configuration options for a progress bar notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.Title">
+            <summary>
+            Gets or sets the progress bar title text.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.ShowCancelButton">
+            <summary>
+            Gets or sets a value indicating whether the cancel button is shown.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.ShowProgress">
+            <summary>
+            Gets or sets a value indicating whether the progress bar is visible.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.AreaName">
+            <summary>
+            Gets or sets the name of the notification area where the progress bar is displayed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.TrimText">
+            <summary>
+            Gets or sets a value indicating whether long text should be trimmed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.DefaultRowsCount">
+            <summary>
+            Gets or sets the default number of visible text rows.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.BaseWaitingMessage">
+            <summary>
+            Gets or sets the base message displayed while calculating estimated remaining time.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.IsCollapse">
+            <summary>
+            Gets or sets a value indicating whether the progress bar can be collapsed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.TitleWhenCollapsed">
+            <summary>
+            Gets or sets a value indicating whether the title is shown when the progress bar is collapsed.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.BackgroundColor">
+            <summary>
+            Gets or sets the custom background color for the progress bar notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.ForegroundColor">
+            <summary>
+            Gets or sets the custom foreground (text) color for the progress bar notification.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.ProgressColor">
+            <summary>
+            Gets or sets the color of the progress indicator.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.Icon">
+            <summary>
+            Gets or sets the icon displayed in the progress bar notification. The type is platform-dependent.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.TitleSettings">
+            <summary>
+            Gets or sets the text rendering settings for the title.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.MessageSettings">
+            <summary>
+            Gets or sets the text rendering settings for the message.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.ProgressBarOptions.ShowCloseButton">
+            <summary>
+            Gets or sets a value indicating whether the close button is visible.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.OperationTimer">
+            <summary>
+            Estimates the remaining time for a long-running operation based on elapsed time and current progress.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.OperationTimer.BaseWaitingMessage">
+            <summary>
+            Gets or sets the message displayed while the initial time estimate is being calculated.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.#ctor(System.String)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.OperationTimer"/> class with a custom waiting message.
+            </summary>
+            <param name="waitingMessage">The message displayed while calculating the initial estimate.</param>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.OperationTimer"/> class with the default waiting message.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.Start">
+            <summary>
+            Starts or resumes the internal stopwatch.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.Stop">
+            <summary>
+            Stops the internal stopwatch.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.Reset">
+            <summary>
+            Resets the internal stopwatch and restarts timing from zero.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.Restart">
+            <summary>
+            Restarts the internal stopwatch, resetting the elapsed time to zero and starting immediately.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.CalculateOperationTime(System.Int32,System.Int32)">
+            <summary>
+            Calculates the estimated remaining operation time based on integer progress indices.
+            </summary>
+            <param name="currentIndex">The current progress index (items completed).</param>
+            <param name="totalIndex">The total number of items to process.</param>
+            <returns>The estimated remaining time, or null if the estimate cannot be calculated yet.</returns>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.GetStringTime(System.Int32,System.Int32)">
+            <summary>
+            Returns the estimated remaining time as a human-readable string based on integer progress indices.
+            </summary>
+            <param name="currentIndex">The current progress index (items completed).</param>
+            <param name="totalIndex">The total number of items to process.</param>
+            <returns>A formatted time string, or the base waiting message if the estimate is not yet available.</returns>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.CalculateOperationTime(System.Double,System.Double)">
+            <summary>
+            Calculates the estimated remaining operation time based on double progress values, using a smoothed average.
+            </summary>
+            <param name="currentIndex">The current progress value.</param>
+            <param name="totalIndex">The total progress target value.</param>
+            <returns>The estimated remaining time, or null if the estimate cannot be calculated yet.</returns>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.GetStringTime(System.Double,System.Double)">
+            <summary>
+            Returns the estimated remaining time as a human-readable string, formatted as days, hours, minutes, or seconds.
+            </summary>
+            <param name="currentIndex">The current progress value.</param>
+            <param name="totalIndex">The total progress target value.</param>
+            <returns>A formatted time string, or the base waiting message if the estimate is not yet available.</returns>
+        </member>
+        <member name="M:Notification.Core.OperationTimer.Dispose">
+            <summary>
+            Releases the internal stopwatch resources.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.ProgressSelector`2">
+            <summary>
+            Adapts an <see cref="T:System.IProgress`1"/> to accept a different source type by applying a selector function.
+            </summary>
+            <typeparam name="T">The target progress value type.</typeparam>
+            <typeparam name="TSource">The source progress value type.</typeparam>
+        </member>
+        <member name="M:Notification.Core.ProgressSelector`2.#ctor(System.IProgress{`0},System.Func{`1,`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.ProgressSelector`2"/> class.
+            </summary>
+            <param name="progress">The target progress reporter to delegate to.</param>
+            <param name="selector">A function that transforms the source value to the target type.</param>
+        </member>
+        <member name="M:Notification.Core.ProgressSelector`2.Report(`1)">
+            <summary>
+            Reports the source progress value after transforming it using the selector function.
+            </summary>
+            <param name="value">The source progress value.</param>
+        </member>
+        <member name="T:Notification.Core.ProgressExtensions">
+            <summary>
+            Provides extension methods for <see cref="T:System.IProgress`1"/> to enable type projection.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.ProgressExtensions.Select``2(System.IProgress{``1},System.Func{``0,``1})">
+            <summary>
+            Projects the source progress type into the target progress type using a selector function.
+            </summary>
+            <typeparam name="TSource">The source progress value type.</typeparam>
+            <typeparam name="T">The target progress value type.</typeparam>
+            <param name="progress">The target progress reporter. If null, returns null.</param>
+            <param name="selector">A function that transforms the source value to the target type.</param>
+            <returns>An <see cref="T:System.IProgress`1"/> that projects values to the target progress, or null if the input progress is null.</returns>
+        </member>
+        <member name="T:Notification.Core.SlowedProgress`1">
+            <summary>
+            A progress reporter that throttles update notifications to prevent excessive UI refreshes.
+            Reports are suppressed if they occur more frequently than the specified timeout interval.
+            </summary>
+            <typeparam name="T">The type of the progress value.</typeparam>
+        </member>
+        <member name="M:Notification.Core.SlowedProgress`1.#ctor(System.Action{`0},System.Int32)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.SlowedProgress`1"/> class with a handler and throttle interval.
+            </summary>
+            <param name="handler">The action invoked when a progress update is reported (subject to throttling).</param>
+            <param name="updateTimeOut">The minimum interval in milliseconds between progress reports.</param>
+        </member>
+        <member name="M:Notification.Core.SlowedProgress`1.OnReport(`0)">
+            <summary>
+            Reports a progress update, suppressing it if the throttle interval has not elapsed since the last report.
+            </summary>
+            <param name="value">The progress value to report.</param>
+        </member>
+        <member name="M:Notification.Core.SlowedProgress`1.Dispose">
+            <summary>
+            Releases the internal stopwatch resources.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.INotificationQueue">
+            <summary>
+            Provides a queue for scheduling notifications when the maximum display count is reached.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.INotificationQueue.Enqueue(Notification.Core.NotificationRequest)">
+            <summary>
+            Adds a notification request to the pending queue.
+            </summary>
+            <param name="request">The notification request to enqueue.</param>
+            <returns>The unique identifier assigned to the queued notification.</returns>
+        </member>
+        <member name="P:Notification.Core.INotificationQueue.PendingCount">
+            <summary>
+            Gets the number of notifications currently waiting in the queue.
+            </summary>
+        </member>
+        <member name="T:Notification.Core.NotificationQueue">
+            <summary>
+            Manages a queue of notification requests with support for group-based deduplication.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationQueue.#ctor(Notification.Core.INotificationService)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Core.NotificationQueue"/> class.
+            </summary>
+            <param name="service">The notification service used to display notifications.</param>
+            <exception cref="T:System.ArgumentNullException">Thrown when <paramref name="service"/> is null.</exception>
+        </member>
+        <member name="M:Notification.Core.NotificationQueue.Enqueue(Notification.Core.NotificationRequest)">
+            <summary>
+            Enqueues a notification request for display. If a notification with the same group key is already active, returns the existing notification identifier.
+            </summary>
+            <param name="request">The notification request to enqueue.</param>
+            <returns>The unique identifier of the displayed or existing notification.</returns>
+        </member>
+        <member name="P:Notification.Core.NotificationQueue.PendingCount">
+            <summary>
+            Gets the number of pending notifications in the queue.
+            </summary>
+        </member>
+        <member name="M:Notification.Core.NotificationQueue.RemoveGroup(System.String)">
+            <summary>
+            Removes a notification group by its key, allowing new notifications with the same key to be displayed.
+            </summary>
+            <param name="groupKey">The group key to remove. If null, no action is taken.</param>
+        </member>
     </members>
 </doc>

--- a/src/Notification.Core/Progress/OperationTimer.cs
+++ b/src/Notification.Core/Progress/OperationTimer.cs
@@ -3,8 +3,14 @@ using System.Diagnostics;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Estimates the remaining time for a long-running operation based on elapsed time and current progress.
+    /// </summary>
     public class OperationTimer : IDisposable
     {
+        /// <summary>
+        /// Gets or sets the message displayed while the initial time estimate is being calculated.
+        /// </summary>
         public string BaseWaitingMessage { get; set; } = "Calculating time";
 
         private Stopwatch Watch { get; set; } = new Stopwatch();
@@ -13,9 +19,20 @@ namespace Notification.Core
 
         private bool IsRunning { get; set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationTimer"/> class with a custom waiting message.
+        /// </summary>
+        /// <param name="waitingMessage">The message displayed while calculating the initial estimate.</param>
         public OperationTimer(string waitingMessage) => BaseWaitingMessage = waitingMessage;
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OperationTimer"/> class with the default waiting message.
+        /// </summary>
         public OperationTimer() { }
 
+        /// <summary>
+        /// Starts or resumes the internal stopwatch.
+        /// </summary>
         public void Start()
         {
             Watch?.Start();
@@ -23,6 +40,9 @@ namespace Notification.Core
             IsRunning = true;
         }
 
+        /// <summary>
+        /// Stops the internal stopwatch.
+        /// </summary>
         public void Stop()
         {
             Watch?.Stop();
@@ -30,6 +50,9 @@ namespace Notification.Core
             IsRunning = false;
         }
 
+        /// <summary>
+        /// Resets the internal stopwatch and restarts timing from zero.
+        /// </summary>
         public void Reset()
         {
             Watch?.Reset();
@@ -37,6 +60,9 @@ namespace Notification.Core
             IsRunning = true;
         }
 
+        /// <summary>
+        /// Restarts the internal stopwatch, resetting the elapsed time to zero and starting immediately.
+        /// </summary>
         public void Restart()
         {
             Watch?.Restart();
@@ -44,12 +70,30 @@ namespace Notification.Core
             IsRunning = true;
         }
 
+        /// <summary>
+        /// Calculates the estimated remaining operation time based on integer progress indices.
+        /// </summary>
+        /// <param name="currentIndex">The current progress index (items completed).</param>
+        /// <param name="totalIndex">The total number of items to process.</param>
+        /// <returns>The estimated remaining time, or null if the estimate cannot be calculated yet.</returns>
         public TimeSpan? CalculateOperationTime(int currentIndex, int totalIndex) =>
             CalculateOperationTime((double)currentIndex, (double)totalIndex);
 
+        /// <summary>
+        /// Returns the estimated remaining time as a human-readable string based on integer progress indices.
+        /// </summary>
+        /// <param name="currentIndex">The current progress index (items completed).</param>
+        /// <param name="totalIndex">The total number of items to process.</param>
+        /// <returns>A formatted time string, or the base waiting message if the estimate is not yet available.</returns>
         public string GetStringTime(int currentIndex, int totalIndex) =>
             GetStringTime((double)currentIndex, (double)totalIndex);
 
+        /// <summary>
+        /// Calculates the estimated remaining operation time based on double progress values, using a smoothed average.
+        /// </summary>
+        /// <param name="currentIndex">The current progress value.</param>
+        /// <param name="totalIndex">The total progress target value.</param>
+        /// <returns>The estimated remaining time, or null if the estimate cannot be calculated yet.</returns>
         public TimeSpan? CalculateOperationTime(double currentIndex, double totalIndex)
         {
             if (Watch is null)
@@ -76,6 +120,12 @@ namespace Notification.Core
             }
         }
 
+        /// <summary>
+        /// Returns the estimated remaining time as a human-readable string, formatted as days, hours, minutes, or seconds.
+        /// </summary>
+        /// <param name="currentIndex">The current progress value.</param>
+        /// <param name="totalIndex">The total progress target value.</param>
+        /// <returns>A formatted time string, or the base waiting message if the estimate is not yet available.</returns>
         public string GetStringTime(double currentIndex, double totalIndex)
         {
             TimeSpan? time = CalculateOperationTime(currentIndex, totalIndex);
@@ -86,6 +136,9 @@ namespace Notification.Core
                 $"{Math.Round(time.Value.TotalSeconds, 0)} s";
         }
 
+        /// <summary>
+        /// Releases the internal stopwatch resources.
+        /// </summary>
         public void Dispose() => Watch = null;
     }
 }

--- a/src/Notification.Core/Progress/ProgressExtensions.cs
+++ b/src/Notification.Core/Progress/ProgressExtensions.cs
@@ -2,22 +2,47 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Adapts an <see cref="IProgress{T}"/> to accept a different source type by applying a selector function.
+    /// </summary>
+    /// <typeparam name="T">The target progress value type.</typeparam>
+    /// <typeparam name="TSource">The source progress value type.</typeparam>
     public class ProgressSelector<T, TSource> : IProgress<TSource>
     {
         private readonly IProgress<T> _progress;
         private readonly Func<TSource, T> _selector;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="ProgressSelector{T, TSource}"/> class.
+        /// </summary>
+        /// <param name="progress">The target progress reporter to delegate to.</param>
+        /// <param name="selector">A function that transforms the source value to the target type.</param>
         public ProgressSelector(IProgress<T> progress, Func<TSource, T> selector)
         {
             _progress = progress;
             _selector = selector;
         }
 
+        /// <summary>
+        /// Reports the source progress value after transforming it using the selector function.
+        /// </summary>
+        /// <param name="value">The source progress value.</param>
         public void Report(TSource value) => _progress.Report(_selector(value));
     }
 
+    /// <summary>
+    /// Provides extension methods for <see cref="IProgress{T}"/> to enable type projection.
+    /// </summary>
     public static class ProgressExtensions
     {
+        /// <summary>
+        /// Projects the source progress type into the target progress type using a selector function.
+        /// </summary>
+        /// <typeparam name="TSource">The source progress value type.</typeparam>
+        /// <typeparam name="T">The target progress value type.</typeparam>
+        /// <param name="progress">The target progress reporter. If null, returns null.</param>
+        /// <param name="selector">A function that transforms the source value to the target type.</param>
+        /// <returns>An <see cref="IProgress{TSource}"/> that projects values to the target progress, or null if the input progress is null.</returns>
         public static IProgress<TSource> Select<TSource, T>(this IProgress<T> progress, Func<TSource, T> selector) =>
             progress is null ? null : new ProgressSelector<T, TSource>(progress, selector);
     }

--- a/src/Notification.Core/Progress/ProgressReportExtensions.cs
+++ b/src/Notification.Core/Progress/ProgressReportExtensions.cs
@@ -1,0 +1,63 @@
+using System;
+
+namespace Notification.Core
+{
+    /// <summary>
+    /// Provides convenience extension methods for reporting <see cref="NotificationProgressReport"/>
+    /// values without constructing the struct manually.
+    /// </summary>
+    public static class ProgressReportExtensions
+    {
+        /// <summary>
+        /// Reports a determinate progress update with only a value.
+        /// </summary>
+        /// <param name="progress">The progress reporter. The call is ignored when null.</param>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        public static void Report(this IProgress<NotificationProgressReport> progress, double value)
+            => progress?.Report(new NotificationProgressReport(value, null, null, null));
+
+        /// <summary>
+        /// Reports a determinate progress update with a value and a status message.
+        /// </summary>
+        /// <param name="progress">The progress reporter. The call is ignored when null.</param>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        /// <param name="message">The progress status message.</param>
+        public static void Report(this IProgress<NotificationProgressReport> progress, double value, string message)
+            => progress?.Report(new NotificationProgressReport(value, message, null, null));
+
+        /// <summary>
+        /// Reports a determinate progress update with a value, a status message and a title.
+        /// </summary>
+        /// <param name="progress">The progress reporter. The call is ignored when null.</param>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        public static void Report(this IProgress<NotificationProgressReport> progress, double value, string message, string title)
+            => progress?.Report(new NotificationProgressReport(value, message, title, null));
+
+        /// <summary>
+        /// Reports a determinate progress update with a value, a status message, a title and cancel button visibility.
+        /// </summary>
+        /// <param name="progress">The progress reporter. The call is ignored when null.</param>
+        /// <param name="value">The progress value as a percentage (0-100).</param>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        /// <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        public static void Report(this IProgress<NotificationProgressReport> progress, double value, string message, string title, bool? showCancel)
+            => progress?.Report(new NotificationProgressReport(value, message, title, showCancel));
+
+        /// <summary>
+        /// Reports an indeterminate progress update that carries no numeric value.
+        /// </summary>
+        /// <param name="progress">The progress reporter. The call is ignored when null.</param>
+        /// <param name="message">The progress status message.</param>
+        /// <param name="title">The progress bar title.</param>
+        /// <param name="showCancel">Whether to show the cancel button, or null to keep the current state.</param>
+        public static void ReportIndeterminate(
+            this IProgress<NotificationProgressReport> progress,
+            string message = null,
+            string title = null,
+            bool? showCancel = null)
+            => progress?.Report(new NotificationProgressReport(null, message, title, showCancel));
+    }
+}

--- a/src/Notification.Core/Progress/SlowedProgress.cs
+++ b/src/Notification.Core/Progress/SlowedProgress.cs
@@ -3,17 +3,31 @@ using System.Diagnostics;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// A progress reporter that throttles update notifications to prevent excessive UI refreshes.
+    /// Reports are suppressed if they occur more frequently than the specified timeout interval.
+    /// </summary>
+    /// <typeparam name="T">The type of the progress value.</typeparam>
     public class SlowedProgress<T> : Progress<T>, IDisposable
     {
         private readonly int _updateTimeOut;
         private Stopwatch _watch = new Stopwatch();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="SlowedProgress{T}"/> class with a handler and throttle interval.
+        /// </summary>
+        /// <param name="handler">The action invoked when a progress update is reported (subject to throttling).</param>
+        /// <param name="updateTimeOut">The minimum interval in milliseconds between progress reports.</param>
         public SlowedProgress(Action<T> handler, int updateTimeOut) : base(handler)
         {
             _updateTimeOut = updateTimeOut;
             _watch.Start();
         }
 
+        /// <summary>
+        /// Reports a progress update, suppressing it if the throttle interval has not elapsed since the last report.
+        /// </summary>
+        /// <param name="value">The progress value to report.</param>
         protected override void OnReport(T value)
         {
             if (_watch.ElapsedMilliseconds <= _updateTimeOut)
@@ -22,6 +36,9 @@ namespace Notification.Core
             base.OnReport(value);
         }
 
+        /// <summary>
+        /// Releases the internal stopwatch resources.
+        /// </summary>
         public void Dispose()
         {
             _watch = null;

--- a/src/Notification.Core/Queue/INotificationQueue.cs
+++ b/src/Notification.Core/Queue/INotificationQueue.cs
@@ -2,9 +2,21 @@ using System;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Provides a queue for scheduling notifications when the maximum display count is reached.
+    /// </summary>
     public interface INotificationQueue
     {
+        /// <summary>
+        /// Adds a notification request to the pending queue.
+        /// </summary>
+        /// <param name="request">The notification request to enqueue.</param>
+        /// <returns>The unique identifier assigned to the queued notification.</returns>
         Guid Enqueue(NotificationRequest request);
+
+        /// <summary>
+        /// Gets the number of notifications currently waiting in the queue.
+        /// </summary>
         int PendingCount { get; }
     }
 }

--- a/src/Notification.Core/Queue/NotificationQueue.cs
+++ b/src/Notification.Core/Queue/NotificationQueue.cs
@@ -4,6 +4,9 @@ using System.Collections.Generic;
 
 namespace Notification.Core
 {
+    /// <summary>
+    /// Manages a queue of notification requests with support for group-based deduplication.
+    /// </summary>
     public class NotificationQueue : INotificationQueue
     {
         private readonly INotificationService _service;
@@ -11,11 +14,21 @@ namespace Notification.Core
         private readonly object _lock = new object();
         private readonly List<(NotificationRequest request, int priority)> _pending = new List<(NotificationRequest, int)>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationQueue"/> class.
+        /// </summary>
+        /// <param name="service">The notification service used to display notifications.</param>
+        /// <exception cref="ArgumentNullException">Thrown when <paramref name="service"/> is null.</exception>
         public NotificationQueue(INotificationService service)
         {
             _service = service ?? throw new ArgumentNullException(nameof(service));
         }
 
+        /// <summary>
+        /// Enqueues a notification request for display. If a notification with the same group key is already active, returns the existing notification identifier.
+        /// </summary>
+        /// <param name="request">The notification request to enqueue.</param>
+        /// <returns>The unique identifier of the displayed or existing notification.</returns>
         public Guid Enqueue(NotificationRequest request)
         {
             if (request.GroupKey != null && _activeGroups.TryGetValue(request.GroupKey, out Guid existingId))
@@ -33,6 +46,9 @@ namespace Notification.Core
             return id;
         }
 
+        /// <summary>
+        /// Gets the number of pending notifications in the queue.
+        /// </summary>
         public int PendingCount
         {
             get
@@ -44,6 +60,10 @@ namespace Notification.Core
             }
         }
 
+        /// <summary>
+        /// Removes a notification group by its key, allowing new notifications with the same key to be displayed.
+        /// </summary>
+        /// <param name="groupKey">The group key to remove. If null, no action is taken.</param>
         public void RemoveGroup(string groupKey)
         {
             if (groupKey != null)

--- a/src/Notification.Maui/MauiNotificationManager.cs
+++ b/src/Notification.Maui/MauiNotificationManager.cs
@@ -15,6 +15,9 @@ using Microsoft.Maui.Graphics;
 
 namespace Notification.Maui
 {
+    /// <summary>
+    /// Renders notifications on .NET MAUI platforms using CommunityToolkit Snackbar and Toast.
+    /// </summary>
     public class MauiNotificationManager : INotificationService
     {
         private readonly INotificationConfiguration _config;
@@ -22,16 +25,30 @@ namespace Notification.Maui
         private readonly ConcurrentDictionary<Guid, CancellationTokenSource> _activeNotifications =
             new ConcurrentDictionary<Guid, CancellationTokenSource>();
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MauiNotificationManager"/> class.
+        /// </summary>
         public MauiNotificationManager()
         {
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="MauiNotificationManager"/> class
+        /// with the specified configuration and event service.
+        /// </summary>
+        /// <param name="config">The notification configuration.</param>
+        /// <param name="events">The event service used to raise lifecycle events.</param>
         public MauiNotificationManager(INotificationConfiguration config, INotificationEventService events)
         {
             _config = config;
             _events = events;
         }
 
+        /// <summary>
+        /// Displays the specified notification as a Snackbar or Toast.
+        /// </summary>
+        /// <param name="request">The notification request to display.</param>
+        /// <returns>The unique identifier of the displayed notification.</returns>
         public Guid Show(NotificationRequest request)
         {
             Guid id = request.Id;
@@ -201,6 +218,10 @@ namespace Notification.Maui
         }
 #endif
 
+        /// <summary>
+        /// Dismisses the notification with the specified identifier.
+        /// </summary>
+        /// <param name="notificationId">The identifier of the notification to dismiss.</param>
         public void Dismiss(Guid notificationId)
         {
             CancellationTokenSource cts;
@@ -213,6 +234,9 @@ namespace Notification.Maui
             }
         }
 
+        /// <summary>
+        /// Dismisses all currently active notifications.
+        /// </summary>
         public void DismissAll()
         {
             foreach (KeyValuePair<Guid, CancellationTokenSource> kvp in _activeNotifications.ToArray())

--- a/src/Notification.Maui/Notification.Maui.xml
+++ b/src/Notification.Maui/Notification.Maui.xml
@@ -4,11 +4,62 @@
         <name>Notification.Maui</name>
     </assembly>
     <members>
-        <member name="T:Notification.Maui.Resource">
+        <member name="T:Notification.Maui.MauiNotificationManager">
             <summary>
-            Android Resource Designer class.
-            Exposes the Android Resource designer assembly into the project Namespace.
+            Renders notifications on .NET MAUI platforms using CommunityToolkit Snackbar and Toast.
             </summary>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationManager.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Maui.MauiNotificationManager"/> class.
+            </summary>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationManager.#ctor(Notification.Core.INotificationConfiguration,Notification.Core.INotificationEventService)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Maui.MauiNotificationManager"/> class
+            with the specified configuration and event service.
+            </summary>
+            <param name="config">The notification configuration.</param>
+            <param name="events">The event service used to raise lifecycle events.</param>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationManager.Show(Notification.Core.NotificationRequest)">
+            <summary>
+            Displays the specified notification as a Snackbar or Toast.
+            </summary>
+            <param name="request">The notification request to display.</param>
+            <returns>The unique identifier of the displayed notification.</returns>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationManager.Dismiss(System.Guid)">
+            <summary>
+            Dismisses the notification with the specified identifier.
+            </summary>
+            <param name="notificationId">The identifier of the notification to dismiss.</param>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationManager.DismissAll">
+            <summary>
+            Dismisses all currently active notifications.
+            </summary>
+        </member>
+        <member name="T:Notification.Maui.MauiNotificationServiceCollectionExtensions">
+            <summary>
+            Provides extension methods for registering MAUI notification services.
+            </summary>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationServiceCollectionExtensions.AddMauiNotifications(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the MAUI notification manager and core notification services.
+            </summary>
+            <param name="services">The service collection to add the services to.</param>
+            <param name="configure">An optional delegate to configure the notification settings.</param>
+            <returns>The same service collection instance for chaining.</returns>
+        </member>
+        <member name="M:Notification.Maui.MauiNotificationServiceCollectionExtensions.UseMauiNotifications(Microsoft.Maui.Hosting.MauiAppBuilder,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the MAUI notification services on the application builder.
+            </summary>
+            <param name="builder">The MAUI application builder.</param>
+            <param name="configure">An optional delegate to configure the notification settings.</param>
+            <returns>The same application builder instance for chaining.</returns>
         </member>
         <member name="M:Microsoft.Maui.Controls.ColorAnimationExtensions_Button.TextColorTo(Microsoft.Maui.Controls.Button,Microsoft.Maui.Graphics.Color,System.UInt32,System.UInt32,Microsoft.Maui.Easing,System.Threading.CancellationToken)">
             <summary>

--- a/src/Notification.Maui/ServiceCollectionExtensions.cs
+++ b/src/Notification.Maui/ServiceCollectionExtensions.cs
@@ -6,8 +6,17 @@ using Notification.Core;
 
 namespace Notification.Maui
 {
+    /// <summary>
+    /// Provides extension methods for registering MAUI notification services.
+    /// </summary>
     public static class MauiNotificationServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the MAUI notification manager and core notification services.
+        /// </summary>
+        /// <param name="services">The service collection to add the services to.</param>
+        /// <param name="configure">An optional delegate to configure the notification settings.</param>
+        /// <returns>The same service collection instance for chaining.</returns>
         public static IServiceCollection AddMauiNotifications(
             this IServiceCollection services,
             Action<INotificationConfiguration> configure = null)
@@ -26,6 +35,12 @@ namespace Notification.Maui
             return services;
         }
 
+        /// <summary>
+        /// Registers the MAUI notification services on the application builder.
+        /// </summary>
+        /// <param name="builder">The MAUI application builder.</param>
+        /// <param name="configure">An optional delegate to configure the notification settings.</param>
+        /// <returns>The same application builder instance for chaining.</returns>
         public static MauiAppBuilder UseMauiNotifications(
             this MauiAppBuilder builder,
             Action<INotificationConfiguration> configure = null)

--- a/src/Notification.Wpf/Adapters/ColorExtensions.cs
+++ b/src/Notification.Wpf/Adapters/ColorExtensions.cs
@@ -3,14 +3,36 @@ using Notification.Core;
 
 namespace Notification.Wpf.Adapters
 {
+    /// <summary>
+    /// Provides extension methods to convert colors between the framework-agnostic Core model
+    /// (<see cref="NotificationColor"/>) and WPF brushes (<see cref="Brush"/>).
+    /// </summary>
     public static class ColorExtensions
     {
+        /// <summary>
+        /// Creates a WPF <see cref="SolidColorBrush"/> from a Core <see cref="NotificationColor"/>.
+        /// </summary>
+        /// <param name="color">The Core color to convert, including its alpha channel.</param>
+        /// <returns>A <see cref="SolidColorBrush"/> with the equivalent ARGB color.</returns>
         public static SolidColorBrush ToBrush(this NotificationColor color) =>
             new SolidColorBrush(Color.FromArgb(color.A, color.R, color.G, color.B));
 
+        /// <summary>
+        /// Converts a WPF <see cref="SolidColorBrush"/> into a Core <see cref="NotificationColor"/>.
+        /// </summary>
+        /// <param name="brush">The solid color brush to convert.</param>
+        /// <returns>A <see cref="NotificationColor"/> with the brush's RGBA components.</returns>
         public static NotificationColor ToNotificationColor(this SolidColorBrush brush) =>
             new NotificationColor(brush.Color.R, brush.Color.G, brush.Color.B, brush.Color.A);
 
+        /// <summary>
+        /// Converts a WPF <see cref="Brush"/> into a Core <see cref="NotificationColor"/>.
+        /// </summary>
+        /// <param name="brush">The brush to convert.</param>
+        /// <returns>
+        /// A <see cref="NotificationColor"/> with the RGBA components of the brush when it is a
+        /// <see cref="SolidColorBrush"/>; otherwise <see cref="NotificationColor.DarkGray"/>.
+        /// </returns>
         public static NotificationColor ToNotificationColor(this Brush brush)
         {
             if (brush is SolidColorBrush scb)

--- a/src/Notification.Wpf/Adapters/ImageExtensions.cs
+++ b/src/Notification.Wpf/Adapters/ImageExtensions.cs
@@ -7,8 +7,22 @@ using Notification.Wpf.Classes;
 
 namespace Notification.Wpf.Adapters
 {
+    /// <summary>
+    /// Provides extension methods to convert image data between the framework-agnostic Core model
+    /// (<see cref="NotificationImageData"/>) and the WPF model (<see cref="NotificationImage"/>).
+    /// </summary>
     public static class ImageExtensions
     {
+        /// <summary>
+        /// Converts Core image data into a WPF <see cref="NotificationImage"/>, building an
+        /// <see cref="ImageSource"/> from either a URI or raw byte data.
+        /// </summary>
+        /// <param name="data">The Core image data to convert; may be <see langword="null"/>.</param>
+        /// <returns>
+        /// A <see cref="NotificationImage"/> with a loaded image source and position,
+        /// or <see langword="null"/> if <paramref name="data"/> is <see langword="null"/>.
+        /// When raw data is used, the resulting bitmap is loaded into memory and frozen.
+        /// </returns>
         public static NotificationImage ToWpfImage(this NotificationImageData data)
         {
             if (data == null)
@@ -41,6 +55,15 @@ namespace Notification.Wpf.Adapters
             };
         }
 
+        /// <summary>
+        /// Converts a WPF <see cref="NotificationImage"/> into framework-agnostic Core image data.
+        /// </summary>
+        /// <param name="image">The WPF image to convert; may be <see langword="null"/>.</param>
+        /// <returns>
+        /// A <see cref="NotificationImageData"/> instance carrying the image position,
+        /// or <see langword="null"/> if <paramref name="image"/> is <see langword="null"/>.
+        /// The WPF <see cref="ImageSource"/> itself is not transferred back to the Core model.
+        /// </returns>
         public static NotificationImageData ToCoreImageData(this NotificationImage image)
         {
             if (image == null)

--- a/src/Notification.Wpf/Adapters/TextSettingsExtensions.cs
+++ b/src/Notification.Wpf/Adapters/TextSettingsExtensions.cs
@@ -5,8 +5,20 @@ using Notification.Wpf.Base;
 
 namespace Notification.Wpf.Adapters
 {
+    /// <summary>
+    /// Provides extension methods to convert text settings between the framework-agnostic
+    /// Core model (<see cref="NotificationTextSettings"/>) and the WPF model (<see cref="TextContentSettings"/>).
+    /// </summary>
     public static class TextSettingsExtensions
     {
+        /// <summary>
+        /// Converts framework-agnostic Core text settings into WPF text content settings.
+        /// </summary>
+        /// <param name="settings">The Core text settings to convert; may be <see langword="null"/>.</param>
+        /// <returns>
+        /// A <see cref="TextContentSettings"/> instance with equivalent WPF values,
+        /// or <see langword="null"/> if <paramref name="settings"/> is <see langword="null"/>.
+        /// </returns>
         public static TextContentSettings ToWpfSettings(this NotificationTextSettings settings)
         {
             if (settings == null)
@@ -25,6 +37,15 @@ namespace Notification.Wpf.Adapters
             };
         }
 
+        /// <summary>
+        /// Converts WPF text content settings into framework-agnostic Core text settings.
+        /// </summary>
+        /// <param name="settings">The WPF text content settings to convert; may be <see langword="null"/>.</param>
+        /// <returns>
+        /// A <see cref="NotificationTextSettings"/> instance with equivalent Core values,
+        /// or <see langword="null"/> if <paramref name="settings"/> is <see langword="null"/>.
+        /// The font family defaults to "Segoe UI" when not specified.
+        /// </returns>
         public static NotificationTextSettings ToCoreSettings(this TextContentSettings settings)
         {
             if (settings == null)
@@ -43,6 +64,11 @@ namespace Notification.Wpf.Adapters
             };
         }
 
+        /// <summary>
+        /// Converts a Core <see cref="NotificationFontStyle"/> value into the corresponding WPF <see cref="FontStyle"/>.
+        /// </summary>
+        /// <param name="style">The Core font style to convert.</param>
+        /// <returns>The matching WPF <see cref="FontStyle"/>; defaults to <see cref="FontStyles.Normal"/>.</returns>
         public static FontStyle ToWpfFontStyle(this NotificationFontStyle style) => style switch
         {
             NotificationFontStyle.Italic => FontStyles.Italic,
@@ -50,6 +76,11 @@ namespace Notification.Wpf.Adapters
             _ => FontStyles.Normal
         };
 
+        /// <summary>
+        /// Converts a WPF <see cref="FontStyle"/> value into the corresponding Core <see cref="NotificationFontStyle"/>.
+        /// </summary>
+        /// <param name="style">The WPF font style to convert.</param>
+        /// <returns>The matching Core <see cref="NotificationFontStyle"/>; defaults to <see cref="NotificationFontStyle.Normal"/>.</returns>
         public static NotificationFontStyle ToCoreStyle(this FontStyle style)
         {
             if (style == FontStyles.Italic) return NotificationFontStyle.Italic;
@@ -57,12 +88,29 @@ namespace Notification.Wpf.Adapters
             return NotificationFontStyle.Normal;
         }
 
+        /// <summary>
+        /// Converts a Core <see cref="NotificationFontWeight"/> value into a WPF <see cref="FontWeight"/>
+        /// using its OpenType numeric weight.
+        /// </summary>
+        /// <param name="weight">The Core font weight to convert.</param>
+        /// <returns>The matching WPF <see cref="FontWeight"/>.</returns>
         public static FontWeight ToWpfFontWeight(this NotificationFontWeight weight) =>
             FontWeight.FromOpenTypeWeight((int)weight);
 
+        /// <summary>
+        /// Converts a WPF <see cref="FontWeight"/> value into a Core <see cref="NotificationFontWeight"/>
+        /// using its OpenType numeric weight.
+        /// </summary>
+        /// <param name="weight">The WPF font weight to convert.</param>
+        /// <returns>The matching Core <see cref="NotificationFontWeight"/>.</returns>
         public static NotificationFontWeight ToCoreWeight(this FontWeight weight) =>
             (NotificationFontWeight)weight.ToOpenTypeWeight();
 
+        /// <summary>
+        /// Converts a Core <see cref="NotificationTextAlignment"/> value into the corresponding WPF <see cref="TextAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The Core text alignment to convert.</param>
+        /// <returns>The matching WPF <see cref="TextAlignment"/>; defaults to <see cref="TextAlignment.Left"/>.</returns>
         public static TextAlignment ToWpfTextAlignment(this NotificationTextAlignment alignment) => alignment switch
         {
             NotificationTextAlignment.Center => TextAlignment.Center,
@@ -71,6 +119,11 @@ namespace Notification.Wpf.Adapters
             _ => TextAlignment.Left
         };
 
+        /// <summary>
+        /// Converts a WPF <see cref="TextAlignment"/> value into the corresponding Core <see cref="NotificationTextAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The WPF text alignment to convert.</param>
+        /// <returns>The matching Core <see cref="NotificationTextAlignment"/>; defaults to <see cref="NotificationTextAlignment.Left"/>.</returns>
         public static NotificationTextAlignment ToCoreAlignment(this TextAlignment alignment) => alignment switch
         {
             TextAlignment.Center => NotificationTextAlignment.Center,
@@ -79,6 +132,11 @@ namespace Notification.Wpf.Adapters
             _ => NotificationTextAlignment.Left
         };
 
+        /// <summary>
+        /// Converts a Core <see cref="NotificationHorizontalAlignment"/> value into the corresponding WPF <see cref="HorizontalAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The Core horizontal alignment to convert.</param>
+        /// <returns>The matching WPF <see cref="HorizontalAlignment"/>; defaults to <see cref="HorizontalAlignment.Stretch"/>.</returns>
         public static HorizontalAlignment ToWpfHorizontalAlignment(this NotificationHorizontalAlignment alignment) => alignment switch
         {
             NotificationHorizontalAlignment.Left => HorizontalAlignment.Left,
@@ -87,6 +145,11 @@ namespace Notification.Wpf.Adapters
             _ => HorizontalAlignment.Stretch
         };
 
+        /// <summary>
+        /// Converts a WPF <see cref="HorizontalAlignment"/> value into the corresponding Core <see cref="NotificationHorizontalAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The WPF horizontal alignment to convert.</param>
+        /// <returns>The matching Core <see cref="NotificationHorizontalAlignment"/>; defaults to <see cref="NotificationHorizontalAlignment.Stretch"/>.</returns>
         public static NotificationHorizontalAlignment ToCoreHorizontalAlignment(this HorizontalAlignment alignment) => alignment switch
         {
             HorizontalAlignment.Left => NotificationHorizontalAlignment.Left,
@@ -95,6 +158,11 @@ namespace Notification.Wpf.Adapters
             _ => NotificationHorizontalAlignment.Stretch
         };
 
+        /// <summary>
+        /// Converts a Core <see cref="NotificationVerticalAlignment"/> value into the corresponding WPF <see cref="VerticalAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The Core vertical alignment to convert.</param>
+        /// <returns>The matching WPF <see cref="VerticalAlignment"/>; defaults to <see cref="VerticalAlignment.Stretch"/>.</returns>
         public static VerticalAlignment ToWpfVerticalAlignment(this NotificationVerticalAlignment alignment) => alignment switch
         {
             NotificationVerticalAlignment.Top => VerticalAlignment.Top,
@@ -103,6 +171,11 @@ namespace Notification.Wpf.Adapters
             _ => VerticalAlignment.Stretch
         };
 
+        /// <summary>
+        /// Converts a WPF <see cref="VerticalAlignment"/> value into the corresponding Core <see cref="NotificationVerticalAlignment"/>.
+        /// </summary>
+        /// <param name="alignment">The WPF vertical alignment to convert.</param>
+        /// <returns>The matching Core <see cref="NotificationVerticalAlignment"/>; defaults to <see cref="NotificationVerticalAlignment.Stretch"/>.</returns>
         public static NotificationVerticalAlignment ToCoreVerticalAlignment(this VerticalAlignment alignment) => alignment switch
         {
             VerticalAlignment.Top => NotificationVerticalAlignment.Top,

--- a/src/Notification.Wpf/Base/Interfaces/Base/IButtonMessageManager.cs
+++ b/src/Notification.Wpf/Base/Interfaces/Base/IButtonMessageManager.cs
@@ -5,6 +5,9 @@ using Notifications.Wpf.Annotations;
 
 namespace Notification.Wpf.Base.Interfaces.Base
 {
+    /// <summary>
+    /// Defines methods for showing notification windows that contain interactive buttons.
+    /// </summary>
     public interface IButtonMessageManager
     {
 

--- a/src/Notification.Wpf/Base/Interfaces/Base/IProgressManager.cs
+++ b/src/Notification.Wpf/Base/Interfaces/Base/IProgressManager.cs
@@ -1,4 +1,6 @@
-﻿using System.Windows.Media;
+﻿using System;
+using System.Windows.Media;
+using Notification.Core;
 using Notification.Wpf.Classes;
 using Notification.Wpf.Constants;
 
@@ -7,6 +9,13 @@ namespace Notification.Wpf.Base.Interfaces.Base
     /// <summary> Progress message manager </summary>
     public interface IProgressManager
     {
+        /// <summary>
+        /// Shows a progress bar notification configured through a <see cref="ProgressBarOptions"/> object.
+        /// </summary>
+        /// <param name="options">The progress bar configuration. Cannot be null.</param>
+        /// <returns>A progress reporter used to update and complete the progress bar.</returns>
+        NotifierProgress<NotificationProgressReport> ShowProgressBar(ProgressBarOptions options);
+
         /// <summary> Show ProgressBar </summary>
         /// <param name="Title">Title of window</param>
         /// <param name="ShowProgress">Show or not progress status</param>
@@ -24,6 +33,7 @@ namespace Notification.Wpf.Base.Interfaces.Base
         /// <param name="TitleSettings">Настройки отображения Title</param>
         /// <param name="MessageSettings">Настройки отображения сообщения</param>
         /// <param name="ShowXbtn">Show X (close) btn</param>
+        [Obsolete("Use ShowProgressBar(ProgressBarOptions) instead — it replaces the long positional parameter list with a configurable options object.")]
         NotifierProgress<NotificationProgressReport> ShowProgressBar(
             string Title = null,
             bool ShowCancelButton = true,

--- a/src/Notification.Wpf/Base/Interfaces/Options/IButtonOptions.cs
+++ b/src/Notification.Wpf/Base/Interfaces/Options/IButtonOptions.cs
@@ -2,6 +2,9 @@
 
 namespace Notification.Wpf.Base.Interfaces.Options
 {
+    /// <summary>
+    /// Defines the content and actions for the left and right buttons of a notification.
+    /// </summary>
     public interface IButtonOptions
     {
         #region Left button

--- a/src/Notification.Wpf/Base/Notification/NotificationContent.cs
+++ b/src/Notification.Wpf/Base/Notification/NotificationContent.cs
@@ -72,6 +72,9 @@ namespace Notification.Wpf
 
         ///<inheritdoc/>
         public bool CloseOnClick { get; set; } = true;
+
+        /// <summary> Action invoked when the notification is right-clicked (issue #54). </summary>
+        public Action RightClickAction { get; set; }
         /// <summary> Get valid options after check for null </summary>
         /// <param name="CloseOnClick"></param>
         /// <param name="options">options</param>

--- a/src/Notification.Wpf/Base/NotificationManager.cs
+++ b/src/Notification.Wpf/Base/NotificationManager.cs
@@ -19,6 +19,8 @@ using Notification.Wpf.Controls;
 using Notifications.Wpf.Annotations;
 using Notifications.Wpf.ViewModels;
 
+using WpfNotification = Notification.Wpf.Controls.Notification;
+
 namespace Notification.Wpf
 {
     /// <inheritdoc />
@@ -383,8 +385,10 @@ namespace Notification.Wpf
         /// <param name="onClose">действие при закрытии</param>
         /// <param name="CloseOnClick">Закрыть сообщение при клике по телу</param>
         /// <param name="ShowXbtn">Show X (close) btn</param>
+        /// <param name="onCreated">Optional callback invoked with each created notification, used to register a programmatic dismiss handle.</param>
         static void ShowContent(object content, TimeSpan? expirationTime = null, string areaName = "",
-            Action onClick = null, Action onClose = null, bool CloseOnClick = true, bool ShowXbtn = true)
+            Action onClick = null, Action onClose = null, bool CloseOnClick = true, bool ShowXbtn = true,
+            Action<WpfNotification> onCreated = null)
         {
             expirationTime ??= TimeSpan.FromSeconds(5);
 
@@ -398,18 +402,30 @@ namespace Notification.Wpf
                     Top = workArea.Top,
                     Width = workArea.Width,
                     Height = workArea.Height,
+                    Topmost = NotificationConstants.OverlayWindowTopmost,
                     CollapseProgressAutoIfMoreMessages = NotificationConstants.CollapseProgressIfMoreRows,
                     MaxWindowItems = NotificationConstants.NotificationsOverlayWindowMaxCount,
                     MessagePosition = NotificationConstants.MessagePosition
                 };
-                _window.Closed += (_, _) =>
-                {
-                    _window = null;
-                };
+                // Drop the reference as soon as the window starts closing so a concurrent
+                // Show() call recreates a fresh window instead of touching a closing one (issue #66).
+                _window.Closing += (_, _) => { _window = null; };
+                _window.Closed += (_, _) => { _window = null; };
             }
 
             if (Areas != null && _window is { IsVisible: false })
-                _window.Show();
+            {
+                try
+                {
+                    _window.Show();
+                }
+                catch (InvalidOperationException)
+                {
+                    // The overlay window is mid-close on another path — discard it; the next call recreates one.
+                    _window = null;
+                    return;
+                }
+            }
 
             if (Areas == null) return;
             foreach (var area in Areas.Where(a => a.Name == areaName))
@@ -420,7 +436,7 @@ namespace Notification.Wpf
                         area.Show(progress, ShowXbtn);
                         break;
                     default:
-                        area.Show(content, (TimeSpan)expirationTime, onClick, onClose, CloseOnClick, ShowXbtn);
+                        area.Show(content, (TimeSpan)expirationTime, onClick, onClose, CloseOnClick, ShowXbtn, onCreated);
                         break;
                 }
             }
@@ -496,6 +512,7 @@ namespace Notification.Wpf
                     LeftButtonContent = request.LeftButtonContent,
                     RightButtonAction = request.RightButtonAction,
                     RightButtonContent = request.RightButtonContent,
+                    RightClickAction = request.OnRightClick,
                     Background = background,
                     Foreground = foreground,
                     TitleTextSettings = titleSettings,
@@ -505,20 +522,32 @@ namespace Notification.Wpf
                 };
             }
 
-            if (_events != null)
+            // Always clean up the dismiss registration when the notification closes,
+            // and raise the Closed lifecycle event when an event service is available.
+            Action originalOnClose = onClose;
+            onClose = () =>
             {
-                Action originalOnClose = onClose;
-                onClose = () =>
+                originalOnClose?.Invoke();
+                _dismissActions.TryRemove(notificationId, out _);
+                _events?.Raise(new NotificationLifecycleEventArgs(
+                    notificationId, NotificationLifecycleStage.Closed, request.Title, request.Message));
+            };
+
+            List<WpfNotification> created = new List<WpfNotification>();
+            ShowContent(content, request.ExpirationTime, request.AreaName ?? "", onClick, onClose,
+                request.CloseOnClick, request.ShowCloseButton, created.Add);
+
+            // Register a dismiss action so Dismiss(id) / DismissAll() can close this notification (issue #48).
+            if (created.Count > 0)
+                _dismissActions[notificationId] = () =>
                 {
-                    originalOnClose?.Invoke();
-                    _dismissActions.TryRemove(notificationId, out _);
-                    _events.Raise(new NotificationLifecycleEventArgs(notificationId, NotificationLifecycleStage.Closed, request.Title, request.Message));
+                    foreach (WpfNotification n in created)
+                        if (!n.IsClosing)
+                            n.Close();
                 };
-            }
 
-            ShowContent(content, request.ExpirationTime, request.AreaName ?? "", onClick, onClose, request.CloseOnClick, request.ShowCloseButton);
-
-            _events?.Raise(new NotificationLifecycleEventArgs(notificationId, NotificationLifecycleStage.Shown, request.Title, request.Message));
+            _events?.Raise(new NotificationLifecycleEventArgs(
+                notificationId, NotificationLifecycleStage.Shown, request.Title, request.Message));
 
             return notificationId;
         }

--- a/src/Notification.Wpf/Base/NotificationManager.cs
+++ b/src/Notification.Wpf/Base/NotificationManager.cs
@@ -186,8 +186,35 @@ namespace Notification.Wpf
 
         #region Progress
 
+        /// <inheritdoc />
+        public NotifierProgress<NotificationProgressReport> ShowProgressBar(ProgressBarOptions options)
+        {
+            if (options is null)
+                throw new ArgumentNullException(nameof(options));
+
+#pragma warning disable CS0618 // delegating to the obsolete positional overload
+            return ShowProgressBar(
+                options.Title,
+                options.ShowCancelButton,
+                options.ShowProgress,
+                options.AreaName ?? "",
+                options.TrimText,
+                options.DefaultRowsCount,
+                options.BaseWaitingMessage,
+                options.IsCollapse,
+                options.TitleWhenCollapsed,
+                options.BackgroundColor?.ToBrush(),
+                options.ForegroundColor?.ToBrush(),
+                options.ProgressColor?.ToBrush(),
+                options.Icon,
+                options.TitleSettings?.ToWpfSettings(),
+                options.MessageSettings?.ToWpfSettings(),
+                options.ShowCloseButton);
+#pragma warning restore CS0618
+        }
 
         /// <inheritdoc />
+        [Obsolete("Use ShowProgressBar(ProgressBarOptions) instead — it replaces the long positional parameter list with a configurable options object.")]
         public NotifierProgress<NotificationProgressReport> ShowProgressBar(string Title = null,
             bool ShowCancelButton = true,
             bool ShowProgress = true,
@@ -202,6 +229,7 @@ namespace Notification.Wpf
 
             if (!_dispatcher.CheckAccess())
             {
+#pragma warning disable CS0618 // marshalling the same obsolete call onto the dispatcher
                 return _dispatcher.Invoke(
                     () => ShowProgressBar(
                         Title,
@@ -214,6 +242,7 @@ namespace Notification.Wpf
                         icon,
                         TitleSettings, MessageSettings,
                         ShowXbtn));
+#pragma warning restore CS0618
             }
 
             var model = new NotificationProgressViewModel(
@@ -407,65 +436,74 @@ namespace Notification.Wpf
                 return _dispatcher.Invoke(() => Show(request));
             }
 
-            Brush background = request.BackgroundColor.HasValue
-                ? request.BackgroundColor.Value.ToBrush()
-                : GetBackgroundForType(request.Type);
-
-            Brush foreground = request.ForegroundColor.HasValue
-                ? request.ForegroundColor.Value.ToBrush()
-                : null;
-
-            if (request.Extensions != null)
-            {
-                if (request.Extensions.TryGetValue("Wpf.Background", out object wpfBg) && wpfBg is Brush bgBrush)
-                    background = bgBrush;
-                if (request.Extensions.TryGetValue("Wpf.Foreground", out object wpfFg) && wpfFg is Brush fgBrush)
-                    foreground = fgBrush;
-            }
-
-            TextContentSettings titleSettings = request.TitleSettings != null
-                ? request.TitleSettings.ToWpfSettings()
-                : NotificationConstants.TitleSettings;
-
-            TextContentSettings messageSettings = request.MessageSettings != null
-                ? request.MessageSettings.ToWpfSettings()
-                : NotificationConstants.MessageSettings;
-
-            if (request.Extensions != null)
-            {
-                if (request.Extensions.TryGetValue("Wpf.TitleSettings", out object wpfTs) && wpfTs is TextContentSettings ts)
-                    titleSettings = ts;
-                if (request.Extensions.TryGetValue("Wpf.MessageSettings", out object wpfMs) && wpfMs is TextContentSettings ms)
-                    messageSettings = ms;
-            }
-
-            NotificationImage image = null;
-            if (request.Extensions != null && request.Extensions.TryGetValue("Wpf.Image", out object wpfImg) && wpfImg is NotificationImage ni)
-                image = ni;
-
-            NotificationContent content = new NotificationContent
-            {
-                Title = request.Title,
-                Message = request.Message,
-                Type = request.Type,
-                TrimType = request.TrimType,
-                RowsCount = request.RowsCount,
-                CloseOnClick = request.CloseOnClick,
-                LeftButtonAction = request.LeftButtonAction,
-                LeftButtonContent = request.LeftButtonContent,
-                RightButtonAction = request.RightButtonAction,
-                RightButtonContent = request.RightButtonContent,
-                Background = background,
-                Foreground = foreground,
-                TitleTextSettings = titleSettings,
-                MessageTextSettings = messageSettings,
-                Icon = request.Icon,
-                Image = image
-            };
-
             Action onClick = request.OnClick;
             Action onClose = request.OnClose;
             Guid notificationId = request.Id;
+
+            object content;
+            if (request.Content != null)
+            {
+                // Arbitrary platform-specific content (for example, a WPF control) is shown as-is.
+                content = request.Content;
+            }
+            else
+            {
+                Brush background = request.BackgroundColor.HasValue
+                    ? request.BackgroundColor.Value.ToBrush()
+                    : GetBackgroundForType(request.Type);
+
+                Brush foreground = request.ForegroundColor.HasValue
+                    ? request.ForegroundColor.Value.ToBrush()
+                    : null;
+
+                if (request.Extensions != null)
+                {
+                    if (request.Extensions.TryGetValue("Wpf.Background", out object wpfBg) && wpfBg is Brush bgBrush)
+                        background = bgBrush;
+                    if (request.Extensions.TryGetValue("Wpf.Foreground", out object wpfFg) && wpfFg is Brush fgBrush)
+                        foreground = fgBrush;
+                }
+
+                TextContentSettings titleSettings = request.TitleSettings != null
+                    ? request.TitleSettings.ToWpfSettings()
+                    : NotificationConstants.TitleSettings;
+
+                TextContentSettings messageSettings = request.MessageSettings != null
+                    ? request.MessageSettings.ToWpfSettings()
+                    : NotificationConstants.MessageSettings;
+
+                if (request.Extensions != null)
+                {
+                    if (request.Extensions.TryGetValue("Wpf.TitleSettings", out object wpfTs) && wpfTs is TextContentSettings ts)
+                        titleSettings = ts;
+                    if (request.Extensions.TryGetValue("Wpf.MessageSettings", out object wpfMs) && wpfMs is TextContentSettings ms)
+                        messageSettings = ms;
+                }
+
+                NotificationImage image = null;
+                if (request.Extensions != null && request.Extensions.TryGetValue("Wpf.Image", out object wpfImg) && wpfImg is NotificationImage ni)
+                    image = ni;
+
+                content = new NotificationContent
+                {
+                    Title = request.Title,
+                    Message = request.Message,
+                    Type = request.Type,
+                    TrimType = request.TrimType,
+                    RowsCount = request.RowsCount,
+                    CloseOnClick = request.CloseOnClick,
+                    LeftButtonAction = request.LeftButtonAction,
+                    LeftButtonContent = request.LeftButtonContent,
+                    RightButtonAction = request.RightButtonAction,
+                    RightButtonContent = request.RightButtonContent,
+                    Background = background,
+                    Foreground = foreground,
+                    TitleTextSettings = titleSettings,
+                    MessageTextSettings = messageSettings,
+                    Icon = request.Icon,
+                    Image = image
+                };
+            }
 
             if (_events != null)
             {

--- a/src/Notification.Wpf/Base/NotificationTemplateSelector.cs
+++ b/src/Notification.Wpf/Base/NotificationTemplateSelector.cs
@@ -4,6 +4,9 @@ using System.Windows.Media;
 
 namespace Notification.Wpf
 {
+    /// <summary>
+    /// Selects the appropriate <see cref="DataTemplate"/> for a notification item based on its content type.
+    /// </summary>
     public class NotificationTemplateSelector : DataTemplateSelector
     {
         private DataTemplate _defaultStringTemplate;
@@ -20,6 +23,12 @@ namespace Notification.Wpf
                     container?.FindResource("DefaultImageSourceTemplate") as DataTemplate;
         }
 
+        /// <summary>
+        /// Returns the <see cref="DataTemplate"/> matching the type of the supplied item.
+        /// </summary>
+        /// <param name="item">The data object for which to select the template.</param>
+        /// <param name="container">The element bound to the data object.</param>
+        /// <returns>The <see cref="DataTemplate"/> that matches the item type, or the base template if none matches.</returns>
         public override DataTemplate SelectTemplate(object item, DependencyObject container)
         {
             if (_defaultStringTemplate == null && _defaultNotificationTemplate == null)

--- a/src/Notification.Wpf/Base/NotificationsOverlayWindow.xaml.cs
+++ b/src/Notification.Wpf/Base/NotificationsOverlayWindow.xaml.cs
@@ -57,6 +57,9 @@ namespace Notification.Wpf
         public bool CollapseProgressAutoIfMoreMessages { get => (bool)GetValue(CollapseProgressAutoIfMoreMessagesProperty); set => SetValue(CollapseProgressAutoIfMoreMessagesProperty, value); }
 
         #endregion
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationsOverlayWindow"/> class.
+        /// </summary>
         public NotificationsOverlayWindow()
         {
             InitializeComponent();

--- a/src/Notification.Wpf/Builder/WpfBuilderExtensions.cs
+++ b/src/Notification.Wpf/Builder/WpfBuilderExtensions.cs
@@ -5,20 +5,55 @@ using Notification.Wpf.Classes;
 
 namespace Notification.Wpf.Builder
 {
+    /// <summary>
+    /// Provides WPF-specific fluent extension methods for <see cref="NotificationBuilder"/>,
+    /// attaching WPF visual data (brushes, images, text settings) as builder extensions.
+    /// </summary>
     public static class WpfBuilderExtensions
     {
+        /// <summary>
+        /// Attaches a WPF background brush to the notification being built.
+        /// </summary>
+        /// <param name="builder">The notification builder to extend.</param>
+        /// <param name="brush">The WPF <see cref="Brush"/> to use as the notification background.</param>
+        /// <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
         public static NotificationBuilder WithBackground(this NotificationBuilder builder, Brush brush) =>
             builder.WithExtension("Wpf.Background", brush);
 
+        /// <summary>
+        /// Attaches a WPF foreground brush to the notification being built.
+        /// </summary>
+        /// <param name="builder">The notification builder to extend.</param>
+        /// <param name="brush">The WPF <see cref="Brush"/> to use as the notification foreground.</param>
+        /// <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
         public static NotificationBuilder WithForeground(this NotificationBuilder builder, Brush brush) =>
             builder.WithExtension("Wpf.Foreground", brush);
 
+        /// <summary>
+        /// Attaches a WPF image to the notification being built.
+        /// </summary>
+        /// <param name="builder">The notification builder to extend.</param>
+        /// <param name="source">The WPF <see cref="ImageSource"/> to display.</param>
+        /// <param name="position">The position of the image within the notification. Defaults to <see cref="ImagePosition.Top"/>.</param>
+        /// <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
         public static NotificationBuilder WithImage(this NotificationBuilder builder, ImageSource source, ImagePosition position = ImagePosition.Top) =>
             builder.WithExtension("Wpf.Image", new NotificationImage { Source = source, Position = position });
 
+        /// <summary>
+        /// Attaches WPF text settings for the notification title to the builder.
+        /// </summary>
+        /// <param name="builder">The notification builder to extend.</param>
+        /// <param name="settings">The WPF <see cref="TextContentSettings"/> to apply to the title.</param>
+        /// <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
         public static NotificationBuilder WithWpfTitleSettings(this NotificationBuilder builder, TextContentSettings settings) =>
             builder.WithExtension("Wpf.TitleSettings", settings);
 
+        /// <summary>
+        /// Attaches WPF text settings for the notification message to the builder.
+        /// </summary>
+        /// <param name="builder">The notification builder to extend.</param>
+        /// <param name="settings">The WPF <see cref="TextContentSettings"/> to apply to the message.</param>
+        /// <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
         public static NotificationBuilder WithWpfMessageSettings(this NotificationBuilder builder, TextContentSettings settings) =>
             builder.WithExtension("Wpf.MessageSettings", settings);
     }

--- a/src/Notification.Wpf/Classes/NotifierProgress.cs
+++ b/src/Notification.Wpf/Classes/NotifierProgress.cs
@@ -106,6 +106,7 @@ namespace Notification.Wpf.Classes
         /// <param name="MultyOrDeVide100"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
         /// <returns>A strongly typed progress instance forwarding values to the notification progress.</returns>
         /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
+        [Obsolete("Tuple-based progress is deprecated. Report a NotificationProgressReport directly (see Report(value, message, title) overloads in ProgressReportExtensions), or use GetValueProgress for plain double progress.")]
         public static IProgress<T> GetProgress<T>(this IProgress<NotificationProgressReport> progress, bool? showCancel, bool? MultyOrDeVide100 = default)
         {
             if (typeof(T) == typeof(double))
@@ -141,6 +142,7 @@ namespace Notification.Wpf.Classes
         /// <param name="UpdateTimeOut">The minimum interval, in milliseconds, between progress updates.</param>
         /// <returns>A throttled strongly typed progress instance forwarding values to the notification progress.</returns>
         /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
+        [Obsolete("Tuple-based progress is deprecated. Use GetSlowedProgress(int) for throttled NotificationProgressReport, or GetSlowedValueProgress for throttled plain double progress.")]
         public static IProgress<T> GetSlowedProgress<T>(
             this IProgress<NotificationProgressReport> progress,
             bool? showCancel,
@@ -169,5 +171,52 @@ namespace Notification.Wpf.Classes
 
             throw new NotSupportedException("type of progress not supported");
         }
+
+        /// <summary>
+        /// Wraps the notification progress so that updates are throttled to at most one per
+        /// <paramref name="updateTimeOut"/> milliseconds.
+        /// </summary>
+        /// <param name="progress">The underlying notification progress to wrap.</param>
+        /// <param name="updateTimeOut">The minimum interval, in milliseconds, between forwarded updates.</param>
+        /// <returns>A throttled progress reporter, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        public static IProgress<NotificationProgressReport> GetSlowedProgress(
+            this IProgress<NotificationProgressReport> progress,
+            int updateTimeOut = 50)
+            => progress is null
+                ? null
+                : new SlowedProgress<NotificationProgressReport>(r => progress.Report(r), updateTimeOut);
+
+        /// <summary>
+        /// Adapts the notification progress to accept plain <see cref="double"/> values.
+        /// </summary>
+        /// <param name="progress">The underlying notification progress to wrap.</param>
+        /// <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+        /// <param name="scale"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+        /// <returns>An <see cref="IProgress{T}"/> of <see cref="double"/> forwarding values to the notification progress, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        public static IProgress<double> GetValueProgress(
+            this IProgress<NotificationProgressReport> progress,
+            bool? showCancel = null,
+            bool? scale = null)
+            => progress.Select<double, NotificationProgressReport>(
+                p => new NotificationProgressReport(ChooseValueDouble(p, scale), null, null, showCancel));
+
+        /// <summary>
+        /// Adapts the notification progress to accept plain <see cref="double"/> values with throttled updates.
+        /// </summary>
+        /// <param name="progress">The underlying notification progress to wrap.</param>
+        /// <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+        /// <param name="scale"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+        /// <param name="updateTimeOut">The minimum interval, in milliseconds, between forwarded updates.</param>
+        /// <returns>A throttled <see cref="IProgress{T}"/> of <see cref="double"/>, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        public static IProgress<double> GetSlowedValueProgress(
+            this IProgress<NotificationProgressReport> progress,
+            bool? showCancel = null,
+            bool? scale = null,
+            int updateTimeOut = 50)
+            => progress is null
+                ? null
+                : new SlowedProgress<double>(
+                    d => progress.Report(new NotificationProgressReport(ChooseValueDouble(d, scale), null, null, showCancel)),
+                    updateTimeOut);
     }
 }

--- a/src/Notification.Wpf/Classes/NotifierProgress.cs
+++ b/src/Notification.Wpf/Classes/NotifierProgress.cs
@@ -6,6 +6,10 @@ using Notification.Wpf.Extensions;
 
 namespace Notification.Wpf.Classes
 {
+    /// <summary>
+    /// Provides progress reporting for a notification operation with cancellation support.
+    /// </summary>
+    /// <typeparam name="T">The type of the progress report value.</typeparam>
     public sealed class NotifierProgress<T> : Progress<T>, IDisposable
     {
         #region IsFinished : bool - progress was finished
@@ -18,17 +22,40 @@ namespace Notification.Wpf.Classes
 
         #endregion
 
+        /// <summary>Timer used to measure the elapsed time of the operation.</summary>
         public readonly OperationTimer WaitingTimer = new();
         private Controls.Notification Area;
         private readonly CancellationTokenSource _CancelSource = new();
+
+        /// <summary>Gets the cancellation token source associated with the operation.</summary>
         public CancellationTokenSource CancelSource => _CancelSource;
+
+        /// <summary>Gets the cancellation token of the operation.</summary>
         public CancellationToken Cancel => _CancelSource.Token;
 
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotifierProgress{T}"/> class with the specified handler and cancellation source.
+        /// </summary>
+        /// <param name="handler">The callback invoked for each reported progress value.</param>
+        /// <param name="source">The cancellation token source associated with the operation.</param>
         public NotifierProgress(Action<T> handler, CancellationTokenSource source) : base(handler) { _CancelSource = source; }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotifierProgress{T}"/> class with the specified handler.
+        /// </summary>
+        /// <param name="handler">The callback invoked for each reported progress value.</param>
         public NotifierProgress(Action<T> handler) : base(handler) { }
+
+        /// <summary>
+        /// Reports a progress update.
+        /// </summary>
+        /// <param name="value">The value of the progress update.</param>
         public void Report(T value) => base.OnReport(value);
 
+        /// <summary>
+        /// Marks the progress as finished, closes the associated notification and releases all resources.
+        /// </summary>
         public void Dispose()
         {
             _IsFinished = true;
@@ -44,12 +71,20 @@ namespace Notification.Wpf.Classes
             }
         }
 
+        /// <summary>
+        /// Associates the notification area that should be closed when the progress is disposed.
+        /// </summary>
+        /// <param name="area">The notification control representing the progress area.</param>
         public void SetArea(Controls.Notification area)
         {
             Area = area;
         }
 
     }
+
+    /// <summary>
+    /// Provides extension methods for converting notification progress into strongly typed progress instances.
+    /// </summary>
     public static class ProgressExtensions
     {
         #region Sub operations
@@ -65,6 +100,12 @@ namespace Notification.Wpf.Classes
         /// <summary>
         /// Get progress of type T: double, (double,string), (double,string,string), int, (int,string), (int,string,string)
         /// </summary>
+        /// <typeparam name="T">The supported progress value type.</typeparam>
+        /// <param name="progress">The underlying notification progress to wrap.</param>
+        /// <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+        /// <param name="MultyOrDeVide100"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+        /// <returns>A strongly typed progress instance forwarding values to the notification progress.</returns>
+        /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
         public static IProgress<T> GetProgress<T>(this IProgress<NotificationProgressReport> progress, bool? showCancel, bool? MultyOrDeVide100 = default)
         {
             if (typeof(T) == typeof(double))
@@ -93,6 +134,13 @@ namespace Notification.Wpf.Classes
         /// <summary>
         /// Get progress of type T with throttling: double, (double,string), (double,string,string), int, (int,string), (int,string,string)
         /// </summary>
+        /// <typeparam name="T">The supported progress value type.</typeparam>
+        /// <param name="progress">The underlying notification progress to wrap.</param>
+        /// <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+        /// <param name="MultyOrDeVide100"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+        /// <param name="UpdateTimeOut">The minimum interval, in milliseconds, between progress updates.</param>
+        /// <returns>A throttled strongly typed progress instance forwarding values to the notification progress.</returns>
+        /// <exception cref="NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
         public static IProgress<T> GetSlowedProgress<T>(
             this IProgress<NotificationProgressReport> progress,
             bool? showCancel,

--- a/src/Notification.Wpf/Command/LamdaCommand.cs
+++ b/src/Notification.Wpf/Command/LamdaCommand.cs
@@ -3,24 +3,44 @@ using System.Windows.Input;
 
 namespace Notifications.Wpf.Command
 {
+    /// <summary>
+    /// An <see cref="ICommand"/> implementation that delegates execution and execution checks to supplied delegates.
+    /// </summary>
     public class LamdaCommand : ICommand
     {
         private readonly Action<object> _OnExecuteAction;
         private readonly Func<object, bool> _CanExecuteFunc;
 
+        /// <summary>
+        /// Determines whether the command can execute in its current state.
+        /// </summary>
+        /// <param name="parameter">Data used by the command; may be <see langword="null"/>.</param>
+        /// <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
         public bool CanExecute(object parameter) { return _CanExecuteFunc?.Invoke(parameter) ?? true; }
 
+        /// <summary>
+        /// Executes the command.
+        /// </summary>
+        /// <param name="parameter">Data used by the command; may be <see langword="null"/>.</param>
         public void Execute(object parameter)
         {
             _OnExecuteAction?.Invoke(parameter);
         }
 
+        /// <summary>
+        /// Occurs when changes happen that affect whether the command should execute.
+        /// </summary>
         public event EventHandler CanExecuteChanged
         {
             add => CommandManager.RequerySuggested += value;
             remove => CommandManager.RequerySuggested -= value;
         }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="LamdaCommand"/> class.
+        /// </summary>
+        /// <param name="OnExecuteAction">The action invoked when the command is executed.</param>
+        /// <param name="CanExecuteFunc">The optional predicate that determines whether the command can execute.</param>
         public LamdaCommand(Action<object> OnExecuteAction, Func<object, bool> CanExecuteFunc = null)
         {
             _OnExecuteAction = OnExecuteAction;

--- a/src/Notification.Wpf/Constants/NotificationConstants.cs
+++ b/src/Notification.Wpf/Constants/NotificationConstants.cs
@@ -59,6 +59,15 @@ namespace Notification.Wpf.Constants
         /// <summary> Overlay message position </summary>
         public static NotificationPosition MessagePosition { get; set; } = NotificationPosition.BottomRight;
 
+        /// <summary> Whether the notification overlay window stays on top of other windows (issue #65) </summary>
+        public static bool OverlayWindowTopmost { get; set; } = true;
+
+        /// <summary> Pause the auto-close timer while the mouse is over the notification (issue #71) </summary>
+        public static bool KeepNotificationVisibleOnMouseOver { get; set; }
+
+        /// <summary> Corner radius of the notification card (issue #52) </summary>
+        public static CornerRadius NotificationCornerRadius { get; set; } = new CornerRadius(0);
+
         /// <summary> Reverse are when absolute </summary>
         public static bool? IsReversedPanel { get; set; }
 

--- a/src/Notification.Wpf/Controls/NotificationArea.cs
+++ b/src/Notification.Wpf/Controls/NotificationArea.cs
@@ -14,6 +14,9 @@ using Notifications.Wpf.ViewModels;
 
 namespace Notification.Wpf.Controls
 {
+    /// <summary>
+    /// Control that hosts and displays notifications within an overlay window.
+    /// </summary>
     public class NotificationArea : Control
     {
         private Window _overlayWindow;
@@ -64,12 +67,14 @@ namespace Notification.Wpf.Controls
 
         #endregion
 
+        /// <summary>Gets or sets the maximum number of notifications displayed simultaneously.</summary>
         public int MaxItems
         {
             get => (int)GetValue(MaxItemsProperty);
             set => SetValue(MaxItemsProperty, value);
         }
 
+        /// <summary>Identifies the <see cref="MaxItems"/> dependency property.</summary>
         public static readonly DependencyProperty MaxItemsProperty =
             DependencyProperty.Register("MaxItems", typeof(int), typeof(NotificationArea), new PropertyMetadata(int.MaxValue));
 
@@ -90,6 +95,9 @@ namespace Notification.Wpf.Controls
 
         private IList _items;
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationArea"/> class.
+        /// </summary>
         public NotificationArea()
         {
             Loaded += NotificationArea_Loaded;
@@ -112,6 +120,9 @@ namespace Notification.Wpf.Controls
                 new FrameworkPropertyMetadata(typeof(NotificationArea)));
         }
 
+        /// <summary>
+        /// Resolves template parts and initializes the reversed layout state after the template is applied.
+        /// </summary>
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();
@@ -122,6 +133,15 @@ namespace Notification.Wpf.Controls
             : Position is NotificationPosition.BottomCenter or NotificationPosition.BottomLeft or NotificationPosition.BottomRight;
         }
 
+        /// <summary>
+        /// Displays a notification with the specified content.
+        /// </summary>
+        /// <param name="content">The content to display inside the notification.</param>
+        /// <param name="expirationTime">The time after which the notification is closed automatically.</param>
+        /// <param name="onClick">Action invoked when the notification is clicked.</param>
+        /// <param name="onClose">Action invoked when the notification is closed.</param>
+        /// <param name="CloseOnClick">Whether the notification should close when clicked.</param>
+        /// <param name="ShowXbtn">Whether to show the close (X) button.</param>
         public async void Show(object content, TimeSpan expirationTime, Action onClick, Action onClose, bool CloseOnClick, bool ShowXbtn)
         {
             Notification notification = new Notification(content, ShowXbtn);
@@ -155,10 +175,10 @@ namespace Notification.Wpf.Controls
         }
 
         /// <summary>
-        /// Отображает окно прогресса
+        /// Displays a progress notification.
         /// </summary>
-        /// <param name="progress">модель прогресс бара</param>
-        /// <param name="ShowXbtn">need to show X close button</param>
+        /// <param name="progress">The progress bar view model.</param>
+        /// <param name="ShowXbtn">Whether to show the close (X) button.</param>
         public async void Show(NotificationProgressViewModel progress, bool ShowXbtn)
         {
             NotificationProgress content = new NotificationProgress { DataContext = progress };
@@ -196,11 +216,11 @@ namespace Notification.Wpf.Controls
         }
 
         /// <summary>
-        /// Добавляет уведомление в список отображения
+        /// Adds a notification to the display list and schedules its automatic removal.
         /// </summary>
-        /// <param name="notification">уведомление</param>
-        /// <param name="expirationTime">время отображения</param>
-        /// <returns></returns>
+        /// <param name="notification">The notification to display.</param>
+        /// <param name="expirationTime">The time after which the notification is closed automatically.</param>
+        /// <returns>A task that completes when the notification has been shown and, if applicable, expired.</returns>
         private async Task OnShowContent(Notification notification, TimeSpan? expirationTime = null)
         {
 

--- a/src/Notification.Wpf/Controls/NotificationArea.cs
+++ b/src/Notification.Wpf/Controls/NotificationArea.cs
@@ -142,9 +142,12 @@ namespace Notification.Wpf.Controls
         /// <param name="onClose">Action invoked when the notification is closed.</param>
         /// <param name="CloseOnClick">Whether the notification should close when clicked.</param>
         /// <param name="ShowXbtn">Whether to show the close (X) button.</param>
-        public async void Show(object content, TimeSpan expirationTime, Action onClick, Action onClose, bool CloseOnClick, bool ShowXbtn)
+        /// <param name="onCreated">Optional callback invoked with the created notification, used to register a programmatic dismiss handle.</param>
+        public async void Show(object content, TimeSpan expirationTime, Action onClick, Action onClose, bool CloseOnClick, bool ShowXbtn,
+            Action<Notification> onCreated = null)
         {
             Notification notification = new Notification(content, ShowXbtn);
+            onCreated?.Invoke(notification);
 
             void OnMouseLeftButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
             {
@@ -159,15 +162,23 @@ namespace Notification.Wpf.Controls
                 (sender as Notification)?.Close(_overlayWindow);
             }
 
+            void OnMouseRightButtonDown(object sender, System.Windows.Input.MouseButtonEventArgs e)
+            {
+                if (content is NotificationContent message)
+                    message.RightClickAction?.Invoke();
+            }
+
             void OnClosed(object sender, RoutedEventArgs e)
             {
                 onClose?.Invoke();
                 notification.MouseLeftButtonDown -= OnMouseLeftButtonDown;
+                notification.MouseRightButtonDown -= OnMouseRightButtonDown;
                 notification.NotificationClosed -= OnClosed;
                 notification.NotificationClosed -= OnNotificationClosed;
             }
 
             notification.MouseLeftButtonDown += OnMouseLeftButtonDown;
+            notification.MouseRightButtonDown += OnMouseRightButtonDown;
             notification.NotificationClosed += OnClosed;
             notification.NotificationClosed += OnNotificationClosed;
 
@@ -262,7 +273,26 @@ namespace Notification.Wpf.Controls
             {
                 return;
             }
-            await Task.Delay((TimeSpan)expirationTime);
+
+            TimeSpan remaining = (TimeSpan)expirationTime;
+            if (NotificationConstants.KeepNotificationVisibleOnMouseOver)
+            {
+                // Count down in small steps; pause while the cursor is over the notification (issue #71).
+                TimeSpan step = TimeSpan.FromMilliseconds(100);
+                while (remaining > TimeSpan.Zero)
+                {
+                    await Task.Delay(step);
+                    if (notification.IsClosing)
+                        return;
+                    if (notification.IsMouseOver)
+                        continue;
+                    remaining -= step;
+                }
+            }
+            else
+            {
+                await Task.Delay(remaining);
+            }
 
             notification.Close(_overlayWindow);
         }

--- a/src/Notification.Wpf/Controls/Notifications/Notification.cs
+++ b/src/Notification.Wpf/Controls/Notifications/Notification.cs
@@ -45,6 +45,8 @@ namespace Notification.Wpf.Controls
 
             MinWidth = max > min ? min : max;
             MaxWidth = max;
+
+            CornerRadius = NotificationConstants.NotificationCornerRadius;
         }
         /// <summary>Builds the visual tree of the control, wiring up the close and attach template buttons and computing the closing animation duration.</summary>
         public override void OnApplyTemplate()
@@ -75,6 +77,21 @@ namespace Notification.Wpf.Controls
 
         /// <summary>X Button visibility</summary>
         public Visibility XbtnVisibility { get => (Visibility)GetValue(XbtnVisibilityProperty); set => SetValue(XbtnVisibilityProperty, value); }
+
+        #endregion
+
+        #region CornerRadius : CornerRadius - Notification card corner radius
+
+        /// <summary>Identifies the <see cref="CornerRadius"/> dependency property.</summary>
+        public static readonly DependencyProperty CornerRadiusProperty =
+            DependencyProperty.Register(
+                nameof(CornerRadius),
+                typeof(CornerRadius),
+                typeof(Notification),
+                new PropertyMetadata(new CornerRadius(0)));
+
+        /// <summary>Gets or sets the corner radius of the notification card.</summary>
+        public CornerRadius CornerRadius { get => (CornerRadius)GetValue(CornerRadiusProperty); set => SetValue(CornerRadiusProperty, value); }
 
         #endregion
 

--- a/src/Notification.Wpf/Controls/Notifications/Notification.cs
+++ b/src/Notification.Wpf/Controls/Notifications/Notification.cs
@@ -17,6 +17,7 @@ using Notifications.Wpf.View;
 
 namespace Notification.Wpf.Controls
 {
+    /// <summary>Represents a notification control that displays content as a toast and supports close and attach interactions.</summary>
     public partial class Notification : ContentControl
     {
         static Notification()
@@ -25,11 +26,15 @@ namespace Notification.Wpf.Controls
                 new FrameworkPropertyMetadata(typeof(Notification)));
         }
 
+        /// <summary>Initializes a new instance of the <see cref="Notification"/> class.</summary>
         public Notification()
         {
 
         }
 
+        /// <summary>Initializes a new instance of the <see cref="Notification"/> class with the specified content and close button visibility.</summary>
+        /// <param name="content">The content to display inside the notification.</param>
+        /// <param name="ShowXbtn"><see langword="true"/> to show the close (X) button; otherwise, <see langword="false"/>.</param>
         public Notification(object content, bool ShowXbtn)
         {
             Content = content;
@@ -41,6 +46,7 @@ namespace Notification.Wpf.Controls
             MinWidth = max > min ? min : max;
             MaxWidth = max;
         }
+        /// <summary>Builds the visual tree of the control, wiring up the close and attach template buttons and computing the closing animation duration.</summary>
         public override void OnApplyTemplate()
         {
             base.OnApplyTemplate();

--- a/src/Notification.Wpf/Controls/Notifications/PART_AttachButton.cs
+++ b/src/Notification.Wpf/Controls/Notifications/PART_AttachButton.cs
@@ -9,34 +9,45 @@ namespace Notification.Wpf.Controls
     public partial class Notification : ContentControl
     {
 
+        /// <summary>Identifies the routed event raised when the notification attach sequence is invoked.</summary>
         public static readonly RoutedEvent NotificationAttachInvokedEvent = EventManager.RegisterRoutedEvent(
             "NotificationAttachInvoked", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(Notification));
 
+        /// <summary>Identifies the routed event raised when the notification is attached.</summary>
         public static readonly RoutedEvent NotificationAttachEvent = EventManager.RegisterRoutedEvent(
             "NotificationAttach", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(Notification));
 
+        /// <summary>Occurs when the notification attach sequence is invoked.</summary>
         public event RoutedEventHandler NotificationAttachInvoked
         {
             add => AddHandler(NotificationAttachInvokedEvent, value);
             remove => RemoveHandler(NotificationAttachInvokedEvent, value);
         }
 
+        /// <summary>Occurs when the notification is attached.</summary>
         public event RoutedEventHandler NotificationAttach
         {
             add => AddHandler(NotificationAttachEvent, value);
             remove => RemoveHandler(NotificationAttachEvent, value);
         }
 
+        /// <summary>Gets the value of the <see cref="AttachOnClickProperty"/> attached property for the specified object.</summary>
+        /// <param name="obj">The object from which to read the attached property value.</param>
+        /// <returns><see langword="true"/> if clicking the element opens the attached content; otherwise, <see langword="false"/>.</returns>
         public static bool GetAttachOnClick(DependencyObject obj)
         {
             return (bool)obj.GetValue(AttachOnClickProperty);
         }
 
+        /// <summary>Sets the value of the <see cref="AttachOnClickProperty"/> attached property for the specified object.</summary>
+        /// <param name="obj">The object on which to set the attached property value.</param>
+        /// <param name="value"><see langword="true"/> to open the attached content when the element is clicked; otherwise, <see langword="false"/>.</param>
         public static void SetAttachOnClick(DependencyObject obj, bool value)
         {
             obj.SetValue(AttachOnClickProperty, value);
         }
 
+        /// <summary>Identifies the AttachOnClick attached property, which opens a window displaying the associated <see cref="NotificationContent"/> when the target button is clicked.</summary>
         public static readonly DependencyProperty AttachOnClickProperty =
             DependencyProperty.RegisterAttached("AttachOnClick", typeof(NotificationContent), typeof(Notification),
                 new FrameworkPropertyMetadata(new NotificationContent
@@ -97,6 +108,7 @@ namespace Notification.Wpf.Controls
             Attach();
         }
 
+        /// <summary>Attaches the notification by raising the close-invoked routed event, unless the notification is already closing.</summary>
         public void Attach()
         {
             if (IsClosing)

--- a/src/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
+++ b/src/Notification.Wpf/Controls/Notifications/PART_CloseButton.cs
@@ -16,37 +16,49 @@ namespace Notification.Wpf.Controls
     {
         private TimeSpan _closingAnimationTime = TimeSpan.Zero;
 
+        /// <summary>Gets or sets a value indicating whether the notification is currently in the process of closing.</summary>
         public bool IsClosing { get; set; }
 
+        /// <summary>Identifies the routed event raised when the notification close sequence is invoked, before the closing animation finishes.</summary>
         public static readonly RoutedEvent NotificationCloseInvokedEvent = EventManager.RegisterRoutedEvent(
             "NotificationCloseInvoked", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(Notification));
 
+        /// <summary>Identifies the routed event raised after the notification has been closed and the closing animation has completed.</summary>
         public static readonly RoutedEvent NotificationClosedEvent = EventManager.RegisterRoutedEvent(
             "NotificationClosed", RoutingStrategy.Bubble, typeof(RoutedEventHandler), typeof(Notification));
 
 
+        /// <summary>Occurs when the notification close sequence is invoked, before the closing animation finishes.</summary>
         public event RoutedEventHandler NotificationCloseInvoked
         {
             add => AddHandler(NotificationCloseInvokedEvent, value);
             remove => RemoveHandler(NotificationCloseInvokedEvent, value);
         }
 
+        /// <summary>Occurs after the notification has been closed and the closing animation has completed.</summary>
         public event RoutedEventHandler NotificationClosed
         {
             add => AddHandler(NotificationClosedEvent, value);
             remove => RemoveHandler(NotificationClosedEvent, value);
         }
 
+        /// <summary>Gets the value of the <see cref="CloseOnClickProperty"/> attached property for the specified object.</summary>
+        /// <param name="obj">The object from which to read the attached property value.</param>
+        /// <returns><see langword="true"/> if clicking the element closes the parent notification; otherwise, <see langword="false"/>.</returns>
         public static bool GetCloseOnClick(DependencyObject obj)
         {
             return (bool)obj.GetValue(CloseOnClickProperty);
         }
 
+        /// <summary>Sets the value of the <see cref="CloseOnClickProperty"/> attached property for the specified object.</summary>
+        /// <param name="obj">The object on which to set the attached property value.</param>
+        /// <param name="value"><see langword="true"/> to close the parent notification when the element is clicked; otherwise, <see langword="false"/>.</param>
         public static void SetCloseOnClick(DependencyObject obj, bool value)
         {
             obj.SetValue(CloseOnClickProperty, value);
         }
 
+        /// <summary>Identifies the CloseOnClick attached property, which closes the parent notification when the target button is clicked.</summary>
         public static readonly DependencyProperty CloseOnClickProperty =
             DependencyProperty.RegisterAttached("CloseOnClick", typeof(bool), typeof(Notification), new FrameworkPropertyMetadata(false, CloseOnClickChanged));
 
@@ -79,6 +91,8 @@ namespace Notification.Wpf.Controls
         }
 
         //TODO: .NET40
+        /// <summary>Closes the notification, raising the close events and closing the host toast window when no notifications remain.</summary>
+        /// <param name="overlayWindow">The optional toast overlay window that hosts the notification. When omitted, the host window is resolved automatically.</param>
         public async void Close(Window overlayWindow = null)
         {
             if (IsClosing)

--- a/src/Notification.Wpf/Controls/ProgresBarAnimateBehavior.cs
+++ b/src/Notification.Wpf/Controls/ProgresBarAnimateBehavior.cs
@@ -7,10 +7,16 @@ using Microsoft.Xaml.Behaviors;
 
 namespace Notification.Wpf.Controls
 {
+    /// <summary>
+    /// Behavior that smoothly animates value changes of an attached <see cref="ProgressBar"/>.
+    /// </summary>
     public class ProgresBarAnimateBehavior : Behavior<ProgressBar>
     {
         bool _IsAnimating;
 
+        /// <summary>
+        /// Called when the behavior is attached to a <see cref="ProgressBar"/>; subscribes to value changes.
+        /// </summary>
         protected override void OnAttached()
         {
             base.OnAttached();
@@ -41,6 +47,9 @@ namespace Notification.Wpf.Controls
             _IsAnimating = false;
         }
 
+        /// <summary>
+        /// Called when the behavior is detached from the <see cref="ProgressBar"/>; unsubscribes from value changes.
+        /// </summary>
         protected override void OnDetaching()
         {
             base.OnDetaching();

--- a/src/Notification.Wpf/Controls/ReversibleStackPanel.cs
+++ b/src/Notification.Wpf/Controls/ReversibleStackPanel.cs
@@ -5,20 +5,30 @@ using System.Windows.Controls;
 
 namespace Notification.Wpf.Controls
 {
+    /// <summary>
+    /// A <see cref="StackPanel"/> that can arrange its children in reverse order.
+    /// </summary>
     public class ReversibleStackPanel : StackPanel
     {
 
 
+        /// <summary>Gets or sets a value indicating whether children are arranged in reverse order.</summary>
         public bool ReverseOrder
         {
             get => (bool)GetValue(ReverseOrderProperty);
             set => SetValue(ReverseOrderProperty, value);
         }
-        
+
+        /// <summary>Identifies the <see cref="ReverseOrder"/> dependency property.</summary>
         public static readonly DependencyProperty ReverseOrderProperty =
             DependencyProperty.Register("ReverseOrder", typeof(bool), typeof(ReversibleStackPanel), new PropertyMetadata(false));
 
 
+        /// <summary>
+        /// Arranges child elements, optionally in reverse order depending on <see cref="ReverseOrder"/>.
+        /// </summary>
+        /// <param name="arrangeSize">The size available to arrange the children.</param>
+        /// <returns>The actual size used by the panel.</returns>
         protected override Size ArrangeOverride(Size arrangeSize)
         {
             double x = 0;

--- a/src/Notification.Wpf/Converters/ValueConverter.cs
+++ b/src/Notification.Wpf/Converters/ValueConverter.cs
@@ -5,13 +5,37 @@ using System.Windows.Markup;
 
 namespace Notification.Wpf.Converters
 {
+    /// <summary>
+    /// Base class for value converters that can also be used directly as a XAML markup extension.
+    /// </summary>
     [MarkupExtensionReturnType(typeof(ValueConverter))]
     public abstract class ValueConverter : MarkupExtension, IValueConverter
     {
+        /// <summary>
+        /// Returns the converter instance itself as the markup extension value.
+        /// </summary>
+        /// <param name="sp">The service provider for the markup extension.</param>
+        /// <returns>The current converter instance.</returns>
         public override object ProvideValue(IServiceProvider sp) => this;
 
+        /// <summary>
+        /// Converts a value from the source to the target.
+        /// </summary>
+        /// <param name="v">The value produced by the binding source.</param>
+        /// <param name="t">The type of the binding target property.</param>
+        /// <param name="p">The converter parameter to use.</param>
+        /// <param name="c">The culture to use in the converter.</param>
+        /// <returns>The converted value.</returns>
         public abstract object Convert(object v, Type t, object p, CultureInfo c);
 
+        /// <summary>
+        /// Converts a value from the target back to the source.
+        /// </summary>
+        /// <param name="v">The value produced by the binding target.</param>
+        /// <param name="t">The type to convert to.</param>
+        /// <param name="p">The converter parameter to use.</param>
+        /// <param name="c">The culture to use in the converter.</param>
+        /// <returns>The converted value.</returns>
         public virtual object ConvertBack(object v, Type t, object p, CultureInfo c) => throw new NotSupportedException();
     }
 }

--- a/src/Notification.Wpf/DependencyInjection/ServiceCollectionExtensions.cs
+++ b/src/Notification.Wpf/DependencyInjection/ServiceCollectionExtensions.cs
@@ -7,8 +7,17 @@ using Notification.Wpf.Controls;
 
 namespace Notification.Wpf.DependencyInjection
 {
+    /// <summary>
+    /// Provides extension methods for registering WPF notification services in an <see cref="IServiceCollection"/>.
+    /// </summary>
     public static class WpfNotificationServiceCollectionExtensions
     {
+        /// <summary>
+        /// Registers the WPF notification manager and related services in the dependency injection container.
+        /// </summary>
+        /// <param name="services">The service collection to add the notification services to.</param>
+        /// <param name="configure">An optional delegate used to configure the notification options.</param>
+        /// <returns>The same <see cref="IServiceCollection"/> instance so that calls can be chained.</returns>
         public static IServiceCollection AddWpfNotifications(
             this IServiceCollection services,
             Action<INotificationConfiguration> configure = null)

--- a/src/Notification.Wpf/Extensions/ColumnDefinitionCollapsable.cs
+++ b/src/Notification.Wpf/Extensions/ColumnDefinitionCollapsable.cs
@@ -3,6 +3,9 @@ using System.Windows.Controls;
 
 namespace Notifications.Wpf.Extensions
 {
+    /// <summary>
+    /// A <see cref="ColumnDefinition"/> that can be collapsed to zero width via the <see cref="Visible"/> property.
+    /// </summary>
     public class ColumnDefinitionCollapsable : ColumnDefinition
     {
         static ColumnDefinitionCollapsable()
@@ -21,7 +24,7 @@ namespace Notifications.Wpf.Extensions
 
         #region Visible : bool - Видимость
 
-        /// <summary>Видимость</summary>
+        /// <summary>Identifies the <see cref="Visible"/> dependency property.</summary>
         public static readonly DependencyProperty VisibleProperty =
             DependencyProperty.Register(
                 nameof(Visible),
@@ -35,7 +38,7 @@ namespace Notifications.Wpf.Extensions
             d.CoerceValue(MinWidthProperty);
         }
 
-        /// <summary>Видимость</summary>
+        /// <summary>Gets or sets a value indicating whether the column is visible; when <c>false</c> the column collapses to zero width.</summary>
         public bool Visible
         {
             get => (bool)GetValue(VisibleProperty);

--- a/src/Notification.Wpf/Extensions/NotificationLineHeightBehavior.cs
+++ b/src/Notification.Wpf/Extensions/NotificationLineHeightBehavior.cs
@@ -8,10 +8,16 @@ using System.Windows.Controls;
 
 namespace Notification.Wpf.Sample.Helpers
 {
+    /// <summary>
+    /// Provides attached properties that size a <see cref="TextBlock"/> by a fixed or maximum number of text lines.
+    /// </summary>
     public class NotificationLineHeightBehavior
     {
         #region Lines count
 
+        /// <summary>
+        /// Identifies the Lines attached property that sets the exact height of a <see cref="TextBlock"/> in lines.
+        /// </summary>
         public static readonly DependencyProperty LinesProperty =
             DependencyProperty.RegisterAttached(
                 "Lines",
@@ -19,8 +25,18 @@ namespace Notification.Wpf.Sample.Helpers
                 typeof(NotificationLineHeightBehavior),
                 new PropertyMetadata(default(int), OnLinesPropertyChangedCallback));
 
+        /// <summary>
+        /// Sets the value of the Lines attached property for the specified <see cref="TextBlock"/>.
+        /// </summary>
+        /// <param name="element">The text block to set the value on.</param>
+        /// <param name="value">The number of lines that defines the text block height.</param>
         public static void SetLines(TextBlock element, int value) => element.SetValue(LinesProperty, value);
 
+        /// <summary>
+        /// Gets the value of the Lines attached property for the specified <see cref="TextBlock"/>.
+        /// </summary>
+        /// <param name="element">The text block to read the value from.</param>
+        /// <returns>The number of lines that defines the text block height.</returns>
         public static int GetLines(TextBlock element) => (int)element.GetValue(LinesProperty);
 
         private static void OnLinesPropertyChangedCallback(
@@ -59,6 +75,9 @@ namespace Notification.Wpf.Sample.Helpers
 
         #region MaxLines
 
+        /// <summary>
+        /// Identifies the MaxLines attached property that sets the maximum height of a <see cref="TextBlock"/> in lines.
+        /// </summary>
         public static readonly DependencyProperty MaxLinesProperty =
             DependencyProperty.RegisterAttached(
                 "MaxLines",
@@ -66,8 +85,18 @@ namespace Notification.Wpf.Sample.Helpers
                 typeof(NotificationLineHeightBehavior),
                 new PropertyMetadata(default(int), OnMaxLinesPropertyChangedCallback));
 
+        /// <summary>
+        /// Sets the value of the MaxLines attached property for the specified <see cref="TextBlock"/>.
+        /// </summary>
+        /// <param name="element">The text block to set the value on.</param>
+        /// <param name="value">The maximum number of lines that defines the text block height.</param>
         public static void SetMaxLines(TextBlock element, int value) => element.SetValue(MaxLinesProperty, value);
 
+        /// <summary>
+        /// Gets the value of the MaxLines attached property for the specified <see cref="TextBlock"/>.
+        /// </summary>
+        /// <param name="element">The text block to read the value from.</param>
+        /// <returns>The maximum number of lines that defines the text block height.</returns>
         public static int GetMaxLines(TextBlock element) => (int)element.GetValue(MaxLinesProperty);
 
         private static void OnMaxLinesPropertyChangedCallback(

--- a/src/Notification.Wpf/Extensions/RowDefinitionCollapsable.cs
+++ b/src/Notification.Wpf/Extensions/RowDefinitionCollapsable.cs
@@ -3,6 +3,9 @@ using System.Windows.Controls;
 
 namespace Notifications.Wpf.Extensions
 {
+    /// <summary>
+    /// A <see cref="RowDefinition"/> that can be collapsed to zero height via the <see cref="Visible"/> property.
+    /// </summary>
     public class RowDefinitionCollapsable : RowDefinition
     {
         static RowDefinitionCollapsable()
@@ -22,7 +25,7 @@ namespace Notifications.Wpf.Extensions
 
         #region Visible : bool - Видимость
 
-        /// <summary>Видимость</summary>
+        /// <summary>Identifies the <see cref="Visible"/> dependency property.</summary>
         public static readonly DependencyProperty VisibleProperty =
             DependencyProperty.Register(
                 nameof(Visible),
@@ -36,7 +39,7 @@ namespace Notifications.Wpf.Extensions
             d.CoerceValue(MinHeightProperty);
         }
 
-        /// <summary>Видимость</summary>
+        /// <summary>Gets or sets a value indicating whether the row is visible; when <c>false</c> the row collapses to zero height.</summary>
         public bool Visible
         {
             get => (bool)GetValue(VisibleProperty);

--- a/src/Notification.Wpf/Notification.Wpf.xml
+++ b/src/Notification.Wpf/Notification.Wpf.xml
@@ -270,6 +270,13 @@
         <member name="T:Notification.Wpf.Base.Interfaces.Base.IProgressManager">
             <summary> Progress message manager </summary>
         </member>
+        <member name="M:Notification.Wpf.Base.Interfaces.Base.IProgressManager.ShowProgressBar(Notification.Core.ProgressBarOptions)">
+            <summary>
+            Shows a progress bar notification configured through a <see cref="T:Notification.Core.ProgressBarOptions"/> object.
+            </summary>
+            <param name="options">The progress bar configuration. Cannot be null.</param>
+            <returns>A progress reporter used to update and complete the progress bar.</returns>
+        </member>
         <member name="M:Notification.Wpf.Base.Interfaces.Base.IProgressManager.ShowProgressBar(System.String,System.Boolean,System.Boolean,System.String,System.Boolean,System.UInt32,System.String,System.Boolean,System.Boolean,System.Windows.Media.Brush,System.Windows.Media.Brush,System.Windows.Media.Brush,System.Object,Notification.Wpf.Base.TextContentSettings,Notification.Wpf.Base.TextContentSettings,System.Boolean)">
             <summary> Show ProgressBar </summary>
             <param name="Title">Title of window</param>
@@ -491,6 +498,9 @@
             <inheritdoc />
         </member>
         <member name="M:Notification.Wpf.NotificationManager.ShowCancellation(Notification.Core.NotificationType,System.String,Notification.Wpf.Base.TextContentSettings,System.Boolean)">
+            <inheritdoc />
+        </member>
+        <member name="M:Notification.Wpf.NotificationManager.ShowProgressBar(Notification.Core.ProgressBarOptions)">
             <inheritdoc />
         </member>
         <member name="M:Notification.Wpf.NotificationManager.ShowProgressBar(System.String,System.Boolean,System.Boolean,System.String,System.Boolean,System.UInt32,System.String,System.Boolean,System.Boolean,System.Windows.Media.Brush,System.Windows.Media.Brush,System.Windows.Media.Brush,System.Object,Notification.Wpf.Base.TextContentSettings,Notification.Wpf.Base.TextContentSettings,System.Boolean)">

--- a/src/Notification.Wpf/Notification.Wpf.xml
+++ b/src/Notification.Wpf/Notification.Wpf.xml
@@ -785,6 +785,34 @@
             <returns>A throttled strongly typed progress instance forwarding values to the notification progress.</returns>
             <exception cref="T:System.NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
         </member>
+        <member name="M:Notification.Wpf.Classes.ProgressExtensions.GetSlowedProgress(System.IProgress{Notification.Core.NotificationProgressReport},System.Int32)">
+            <summary>
+            Wraps the notification progress so that updates are throttled to at most one per
+            <paramref name="updateTimeOut"/> milliseconds.
+            </summary>
+            <param name="progress">The underlying notification progress to wrap.</param>
+            <param name="updateTimeOut">The minimum interval, in milliseconds, between forwarded updates.</param>
+            <returns>A throttled progress reporter, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Classes.ProgressExtensions.GetValueProgress(System.IProgress{Notification.Core.NotificationProgressReport},System.Nullable{System.Boolean},System.Nullable{System.Boolean})">
+            <summary>
+            Adapts the notification progress to accept plain <see cref="T:System.Double"/> values.
+            </summary>
+            <param name="progress">The underlying notification progress to wrap.</param>
+            <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+            <param name="scale"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+            <returns>An <see cref="T:System.IProgress`1"/> of <see cref="T:System.Double"/> forwarding values to the notification progress, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Classes.ProgressExtensions.GetSlowedValueProgress(System.IProgress{Notification.Core.NotificationProgressReport},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Int32)">
+            <summary>
+            Adapts the notification progress to accept plain <see cref="T:System.Double"/> values with throttled updates.
+            </summary>
+            <param name="progress">The underlying notification progress to wrap.</param>
+            <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+            <param name="scale"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+            <param name="updateTimeOut">The minimum interval, in milliseconds, between forwarded updates.</param>
+            <returns>A throttled <see cref="T:System.IProgress`1"/> of <see cref="T:System.Double"/>, or <see langword="null"/> when <paramref name="progress"/> is null.</returns>
+        </member>
         <member name="T:Notification.Wpf.Constants.NotificationConstants">
             <summary> Notification static settings </summary>
         </member>

--- a/src/Notification.Wpf/Notification.Wpf.xml
+++ b/src/Notification.Wpf/Notification.Wpf.xml
@@ -4,6 +4,169 @@
         <name>Notification.Wpf</name>
     </assembly>
     <members>
+        <member name="T:Notification.Wpf.Adapters.ColorExtensions">
+            <summary>
+            Provides extension methods to convert colors between the framework-agnostic Core model
+            (<see cref="T:Notification.Core.NotificationColor"/>) and WPF brushes (<see cref="T:System.Windows.Media.Brush"/>).
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.ColorExtensions.ToBrush(Notification.Core.NotificationColor)">
+            <summary>
+            Creates a WPF <see cref="T:System.Windows.Media.SolidColorBrush"/> from a Core <see cref="T:Notification.Core.NotificationColor"/>.
+            </summary>
+            <param name="color">The Core color to convert, including its alpha channel.</param>
+            <returns>A <see cref="T:System.Windows.Media.SolidColorBrush"/> with the equivalent ARGB color.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.ColorExtensions.ToNotificationColor(System.Windows.Media.SolidColorBrush)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.Media.SolidColorBrush"/> into a Core <see cref="T:Notification.Core.NotificationColor"/>.
+            </summary>
+            <param name="brush">The solid color brush to convert.</param>
+            <returns>A <see cref="T:Notification.Core.NotificationColor"/> with the brush's RGBA components.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.ColorExtensions.ToNotificationColor(System.Windows.Media.Brush)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.Media.Brush"/> into a Core <see cref="T:Notification.Core.NotificationColor"/>.
+            </summary>
+            <param name="brush">The brush to convert.</param>
+            <returns>
+            A <see cref="T:Notification.Core.NotificationColor"/> with the RGBA components of the brush when it is a
+            <see cref="T:System.Windows.Media.SolidColorBrush"/>; otherwise <see cref="F:Notification.Core.NotificationColor.DarkGray"/>.
+            </returns>
+        </member>
+        <member name="T:Notification.Wpf.Adapters.ImageExtensions">
+            <summary>
+            Provides extension methods to convert image data between the framework-agnostic Core model
+            (<see cref="T:Notification.Core.NotificationImageData"/>) and the WPF model (<see cref="T:Notification.Wpf.Classes.NotificationImage"/>).
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.ImageExtensions.ToWpfImage(Notification.Core.NotificationImageData)">
+            <summary>
+            Converts Core image data into a WPF <see cref="T:Notification.Wpf.Classes.NotificationImage"/>, building an
+            <see cref="T:System.Windows.Media.ImageSource"/> from either a URI or raw byte data.
+            </summary>
+            <param name="data">The Core image data to convert; may be <see langword="null"/>.</param>
+            <returns>
+            A <see cref="T:Notification.Wpf.Classes.NotificationImage"/> with a loaded image source and position,
+            or <see langword="null"/> if <paramref name="data"/> is <see langword="null"/>.
+            When raw data is used, the resulting bitmap is loaded into memory and frozen.
+            </returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.ImageExtensions.ToCoreImageData(Notification.Wpf.Classes.NotificationImage)">
+            <summary>
+            Converts a WPF <see cref="T:Notification.Wpf.Classes.NotificationImage"/> into framework-agnostic Core image data.
+            </summary>
+            <param name="image">The WPF image to convert; may be <see langword="null"/>.</param>
+            <returns>
+            A <see cref="T:Notification.Core.NotificationImageData"/> instance carrying the image position,
+            or <see langword="null"/> if <paramref name="image"/> is <see langword="null"/>.
+            The WPF <see cref="T:System.Windows.Media.ImageSource"/> itself is not transferred back to the Core model.
+            </returns>
+        </member>
+        <member name="T:Notification.Wpf.Adapters.TextSettingsExtensions">
+            <summary>
+            Provides extension methods to convert text settings between the framework-agnostic
+            Core model (<see cref="T:Notification.Core.NotificationTextSettings"/>) and the WPF model (<see cref="T:Notification.Wpf.Base.TextContentSettings"/>).
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfSettings(Notification.Core.NotificationTextSettings)">
+            <summary>
+            Converts framework-agnostic Core text settings into WPF text content settings.
+            </summary>
+            <param name="settings">The Core text settings to convert; may be <see langword="null"/>.</param>
+            <returns>
+            A <see cref="T:Notification.Wpf.Base.TextContentSettings"/> instance with equivalent WPF values,
+            or <see langword="null"/> if <paramref name="settings"/> is <see langword="null"/>.
+            </returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreSettings(Notification.Wpf.Base.TextContentSettings)">
+            <summary>
+            Converts WPF text content settings into framework-agnostic Core text settings.
+            </summary>
+            <param name="settings">The WPF text content settings to convert; may be <see langword="null"/>.</param>
+            <returns>
+            A <see cref="T:Notification.Core.NotificationTextSettings"/> instance with equivalent Core values,
+            or <see langword="null"/> if <paramref name="settings"/> is <see langword="null"/>.
+            The font family defaults to "Segoe UI" when not specified.
+            </returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfFontStyle(Notification.Core.NotificationFontStyle)">
+            <summary>
+            Converts a Core <see cref="T:Notification.Core.NotificationFontStyle"/> value into the corresponding WPF <see cref="T:System.Windows.FontStyle"/>.
+            </summary>
+            <param name="style">The Core font style to convert.</param>
+            <returns>The matching WPF <see cref="T:System.Windows.FontStyle"/>; defaults to <see cref="P:System.Windows.FontStyles.Normal"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreStyle(System.Windows.FontStyle)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.FontStyle"/> value into the corresponding Core <see cref="T:Notification.Core.NotificationFontStyle"/>.
+            </summary>
+            <param name="style">The WPF font style to convert.</param>
+            <returns>The matching Core <see cref="T:Notification.Core.NotificationFontStyle"/>; defaults to <see cref="F:Notification.Core.NotificationFontStyle.Normal"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfFontWeight(Notification.Core.NotificationFontWeight)">
+            <summary>
+            Converts a Core <see cref="T:Notification.Core.NotificationFontWeight"/> value into a WPF <see cref="T:System.Windows.FontWeight"/>
+            using its OpenType numeric weight.
+            </summary>
+            <param name="weight">The Core font weight to convert.</param>
+            <returns>The matching WPF <see cref="T:System.Windows.FontWeight"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreWeight(System.Windows.FontWeight)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.FontWeight"/> value into a Core <see cref="T:Notification.Core.NotificationFontWeight"/>
+            using its OpenType numeric weight.
+            </summary>
+            <param name="weight">The WPF font weight to convert.</param>
+            <returns>The matching Core <see cref="T:Notification.Core.NotificationFontWeight"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfTextAlignment(Notification.Core.NotificationTextAlignment)">
+            <summary>
+            Converts a Core <see cref="T:Notification.Core.NotificationTextAlignment"/> value into the corresponding WPF <see cref="T:System.Windows.TextAlignment"/>.
+            </summary>
+            <param name="alignment">The Core text alignment to convert.</param>
+            <returns>The matching WPF <see cref="T:System.Windows.TextAlignment"/>; defaults to <see cref="F:System.Windows.TextAlignment.Left"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreAlignment(System.Windows.TextAlignment)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.TextAlignment"/> value into the corresponding Core <see cref="T:Notification.Core.NotificationTextAlignment"/>.
+            </summary>
+            <param name="alignment">The WPF text alignment to convert.</param>
+            <returns>The matching Core <see cref="T:Notification.Core.NotificationTextAlignment"/>; defaults to <see cref="F:Notification.Core.NotificationTextAlignment.Left"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfHorizontalAlignment(Notification.Core.NotificationHorizontalAlignment)">
+            <summary>
+            Converts a Core <see cref="T:Notification.Core.NotificationHorizontalAlignment"/> value into the corresponding WPF <see cref="T:System.Windows.HorizontalAlignment"/>.
+            </summary>
+            <param name="alignment">The Core horizontal alignment to convert.</param>
+            <returns>The matching WPF <see cref="T:System.Windows.HorizontalAlignment"/>; defaults to <see cref="F:System.Windows.HorizontalAlignment.Stretch"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreHorizontalAlignment(System.Windows.HorizontalAlignment)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.HorizontalAlignment"/> value into the corresponding Core <see cref="T:Notification.Core.NotificationHorizontalAlignment"/>.
+            </summary>
+            <param name="alignment">The WPF horizontal alignment to convert.</param>
+            <returns>The matching Core <see cref="T:Notification.Core.NotificationHorizontalAlignment"/>; defaults to <see cref="F:Notification.Core.NotificationHorizontalAlignment.Stretch"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToWpfVerticalAlignment(Notification.Core.NotificationVerticalAlignment)">
+            <summary>
+            Converts a Core <see cref="T:Notification.Core.NotificationVerticalAlignment"/> value into the corresponding WPF <see cref="T:System.Windows.VerticalAlignment"/>.
+            </summary>
+            <param name="alignment">The Core vertical alignment to convert.</param>
+            <returns>The matching WPF <see cref="T:System.Windows.VerticalAlignment"/>; defaults to <see cref="F:System.Windows.VerticalAlignment.Stretch"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Adapters.TextSettingsExtensions.ToCoreVerticalAlignment(System.Windows.VerticalAlignment)">
+            <summary>
+            Converts a WPF <see cref="T:System.Windows.VerticalAlignment"/> value into the corresponding Core <see cref="T:Notification.Core.NotificationVerticalAlignment"/>.
+            </summary>
+            <param name="alignment">The WPF vertical alignment to convert.</param>
+            <returns>The matching Core <see cref="T:Notification.Core.NotificationVerticalAlignment"/>; defaults to <see cref="F:Notification.Core.NotificationVerticalAlignment.Stretch"/>.</returns>
+        </member>
+        <member name="T:Notification.Wpf.Base.Interfaces.Base.IButtonMessageManager">
+            <summary>
+            Defines methods for showing notification windows that contain interactive buttons.
+            </summary>
+        </member>
         <member name="M:Notification.Wpf.Base.Interfaces.Base.IButtonMessageManager.ShowFilePopUpMessage(System.String,System.Boolean,System.Boolean,System.Nullable{System.TimeSpan},System.String,Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions,Notification.Wpf.Classes.NotificationImage,System.Boolean)">
             <summary>
             Show message with button to open file or directory (file destination)
@@ -164,6 +327,11 @@
         </member>
         <member name="P:Notification.Wpf.Base.Interfaces.ITextContentSettings.Opacity">
             <summary> Text opacity </summary>
+        </member>
+        <member name="T:Notification.Wpf.Base.Interfaces.Options.IButtonOptions">
+            <summary>
+            Defines the content and actions for the left and right buttons of a notification.
+            </summary>
         </member>
         <member name="P:Notification.Wpf.Base.Interfaces.Options.IButtonOptions.LeftButtonContent">
             <summary>
@@ -384,6 +552,11 @@
         <member name="P:Notification.Wpf.NotificationsOverlayWindow.CollapseProgressAutoIfMoreMessages">
             <summary>Need collapse notification if count more that maximum</summary>
         </member>
+        <member name="M:Notification.Wpf.NotificationsOverlayWindow.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Wpf.NotificationsOverlayWindow"/> class.
+            </summary>
+        </member>
         <member name="M:Notification.Wpf.NotificationsOverlayWindow.NotificationsOverlayWindow_Loaded(System.Object,System.Windows.RoutedEventArgs)">
             <summary>
             hide window from taskbar
@@ -395,6 +568,19 @@
             <summary>
             InitializeComponent
             </summary>
+        </member>
+        <member name="T:Notification.Wpf.NotificationTemplateSelector">
+            <summary>
+            Selects the appropriate <see cref="T:System.Windows.DataTemplate"/> for a notification item based on its content type.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.NotificationTemplateSelector.SelectTemplate(System.Object,System.Windows.DependencyObject)">
+            <summary>
+            Returns the <see cref="T:System.Windows.DataTemplate"/> matching the type of the supplied item.
+            </summary>
+            <param name="item">The data object for which to select the template.</param>
+            <param name="container">The element bound to the data object.</param>
+            <returns>The <see cref="T:System.Windows.DataTemplate"/> that matches the item type, or the base template if none matches.</returns>
         </member>
         <member name="T:Notification.Wpf.BaseNotificationContent">
             <inheritdoc cref="T:Notification.Wpf.ICustomizedNotification" />
@@ -443,6 +629,53 @@
             <param name="Image"></param>
             <returns></returns>
         </member>
+        <member name="T:Notification.Wpf.Builder.WpfBuilderExtensions">
+            <summary>
+            Provides WPF-specific fluent extension methods for <see cref="T:Notification.Core.NotificationBuilder"/>,
+            attaching WPF visual data (brushes, images, text settings) as builder extensions.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Builder.WpfBuilderExtensions.WithBackground(Notification.Core.NotificationBuilder,System.Windows.Media.Brush)">
+            <summary>
+            Attaches a WPF background brush to the notification being built.
+            </summary>
+            <param name="builder">The notification builder to extend.</param>
+            <param name="brush">The WPF <see cref="T:System.Windows.Media.Brush"/> to use as the notification background.</param>
+            <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Builder.WpfBuilderExtensions.WithForeground(Notification.Core.NotificationBuilder,System.Windows.Media.Brush)">
+            <summary>
+            Attaches a WPF foreground brush to the notification being built.
+            </summary>
+            <param name="builder">The notification builder to extend.</param>
+            <param name="brush">The WPF <see cref="T:System.Windows.Media.Brush"/> to use as the notification foreground.</param>
+            <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Builder.WpfBuilderExtensions.WithImage(Notification.Core.NotificationBuilder,System.Windows.Media.ImageSource,Notification.Core.ImagePosition)">
+            <summary>
+            Attaches a WPF image to the notification being built.
+            </summary>
+            <param name="builder">The notification builder to extend.</param>
+            <param name="source">The WPF <see cref="T:System.Windows.Media.ImageSource"/> to display.</param>
+            <param name="position">The position of the image within the notification. Defaults to <see cref="F:Notification.Core.ImagePosition.Top"/>.</param>
+            <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Builder.WpfBuilderExtensions.WithWpfTitleSettings(Notification.Core.NotificationBuilder,Notification.Wpf.Base.TextContentSettings)">
+            <summary>
+            Attaches WPF text settings for the notification title to the builder.
+            </summary>
+            <param name="builder">The notification builder to extend.</param>
+            <param name="settings">The WPF <see cref="T:Notification.Wpf.Base.TextContentSettings"/> to apply to the title.</param>
+            <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Builder.WpfBuilderExtensions.WithWpfMessageSettings(Notification.Core.NotificationBuilder,Notification.Wpf.Base.TextContentSettings)">
+            <summary>
+            Attaches WPF text settings for the notification message to the builder.
+            </summary>
+            <param name="builder">The notification builder to extend.</param>
+            <param name="settings">The WPF <see cref="T:Notification.Wpf.Base.TextContentSettings"/> to apply to the message.</param>
+            <returns>The same <paramref name="builder"/> instance for fluent chaining.</returns>
+        </member>
         <member name="T:Notification.Wpf.Classes.AbsolutePosition">
             <summary> Are absolute position </summary>
         </member>
@@ -473,21 +706,84 @@
         <member name="P:Notification.Wpf.Classes.NotificationImage.Position">
             <summary> Image position in view </summary>
         </member>
+        <member name="T:Notification.Wpf.Classes.NotifierProgress`1">
+            <summary>
+            Provides progress reporting for a notification operation with cancellation support.
+            </summary>
+            <typeparam name="T">The type of the progress report value.</typeparam>
+        </member>
         <member name="P:Notification.Wpf.Classes.NotifierProgress`1.IsFinished">
             <summary>progress was finished</summary>
         </member>
         <member name="F:Notification.Wpf.Classes.NotifierProgress`1._IsFinished">
             <summary>progress was finished</summary>
         </member>
+        <member name="F:Notification.Wpf.Classes.NotifierProgress`1.WaitingTimer">
+            <summary>Timer used to measure the elapsed time of the operation.</summary>
+        </member>
+        <member name="P:Notification.Wpf.Classes.NotifierProgress`1.CancelSource">
+            <summary>Gets the cancellation token source associated with the operation.</summary>
+        </member>
+        <member name="P:Notification.Wpf.Classes.NotifierProgress`1.Cancel">
+            <summary>Gets the cancellation token of the operation.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Classes.NotifierProgress`1.#ctor(System.Action{`0},System.Threading.CancellationTokenSource)">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Wpf.Classes.NotifierProgress`1"/> class with the specified handler and cancellation source.
+            </summary>
+            <param name="handler">The callback invoked for each reported progress value.</param>
+            <param name="source">The cancellation token source associated with the operation.</param>
+        </member>
+        <member name="M:Notification.Wpf.Classes.NotifierProgress`1.#ctor(System.Action{`0})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Wpf.Classes.NotifierProgress`1"/> class with the specified handler.
+            </summary>
+            <param name="handler">The callback invoked for each reported progress value.</param>
+        </member>
+        <member name="M:Notification.Wpf.Classes.NotifierProgress`1.Report(`0)">
+            <summary>
+            Reports a progress update.
+            </summary>
+            <param name="value">The value of the progress update.</param>
+        </member>
+        <member name="M:Notification.Wpf.Classes.NotifierProgress`1.Dispose">
+            <summary>
+            Marks the progress as finished, closes the associated notification and releases all resources.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Classes.NotifierProgress`1.SetArea(Notification.Wpf.Controls.Notification)">
+            <summary>
+            Associates the notification area that should be closed when the progress is disposed.
+            </summary>
+            <param name="area">The notification control representing the progress area.</param>
+        </member>
+        <member name="T:Notification.Wpf.Classes.ProgressExtensions">
+            <summary>
+            Provides extension methods for converting notification progress into strongly typed progress instances.
+            </summary>
+        </member>
         <member name="M:Notification.Wpf.Classes.ProgressExtensions.GetProgress``1(System.IProgress{Notification.Core.NotificationProgressReport},System.Nullable{System.Boolean},System.Nullable{System.Boolean})">
             <summary>
             Get progress of type T: double, (double,string), (double,string,string), int, (int,string), (int,string,string)
             </summary>
+            <typeparam name="T">The supported progress value type.</typeparam>
+            <param name="progress">The underlying notification progress to wrap.</param>
+            <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+            <param name="MultyOrDeVide100"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+            <returns>A strongly typed progress instance forwarding values to the notification progress.</returns>
+            <exception cref="T:System.NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
         </member>
         <member name="M:Notification.Wpf.Classes.ProgressExtensions.GetSlowedProgress``1(System.IProgress{Notification.Core.NotificationProgressReport},System.Nullable{System.Boolean},System.Nullable{System.Boolean},System.Int32)">
             <summary>
             Get progress of type T with throttling: double, (double,string), (double,string,string), int, (int,string), (int,string,string)
             </summary>
+            <typeparam name="T">The supported progress value type.</typeparam>
+            <param name="progress">The underlying notification progress to wrap.</param>
+            <param name="showCancel">Whether the cancel button should be shown; <see langword="null"/> keeps the default.</param>
+            <param name="MultyOrDeVide100"><see langword="true"/> multiplies the value by 100, <see langword="false"/> divides by 100, <see langword="null"/> keeps it unchanged.</param>
+            <param name="UpdateTimeOut">The minimum interval, in milliseconds, between progress updates.</param>
+            <returns>A throttled strongly typed progress instance forwarding values to the notification progress.</returns>
+            <exception cref="T:System.NotSupportedException">Thrown when <typeparamref name="T"/> is not a supported progress type.</exception>
         </member>
         <member name="T:Notification.Wpf.Constants.NotificationConstants">
             <summary> Notification static settings </summary>
@@ -591,6 +887,11 @@
         <member name="P:Notification.Wpf.Constants.NotificationConstants.AreaWidth">
             <summary> work area width </summary>
         </member>
+        <member name="T:Notification.Wpf.Controls.NotificationArea">
+            <summary>
+            Control that hosts and displays notifications within an overlay window.
+            </summary>
+        </member>
         <member name="F:Notification.Wpf.Controls.NotificationArea.CollapseProgressAutoProperty">
             <summary>Progress bar will automatically collapsed if items count more that max items</summary>
         </member>
@@ -603,26 +904,67 @@
         <member name="P:Notification.Wpf.Controls.NotificationArea.Position">
             <summary>Area position on overlay window</summary>
         </member>
+        <member name="P:Notification.Wpf.Controls.NotificationArea.MaxItems">
+            <summary>Gets or sets the maximum number of notifications displayed simultaneously.</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.NotificationArea.MaxItemsProperty">
+            <summary>Identifies the <see cref="P:Notification.Wpf.Controls.NotificationArea.MaxItems"/> dependency property.</summary>
+        </member>
         <member name="F:Notification.Wpf.Controls.NotificationArea.IsReversedProperty">
             <summary>Are is reversed</summary>
         </member>
         <member name="P:Notification.Wpf.Controls.NotificationArea.IsReversed">
             <summary>Are is reversed</summary>
         </member>
+        <member name="M:Notification.Wpf.Controls.NotificationArea.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Wpf.Controls.NotificationArea"/> class.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.NotificationArea.OnApplyTemplate">
+            <summary>
+            Resolves template parts and initializes the reversed layout state after the template is applied.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.NotificationArea.Show(System.Object,System.TimeSpan,System.Action,System.Action,System.Boolean,System.Boolean)">
+            <summary>
+            Displays a notification with the specified content.
+            </summary>
+            <param name="content">The content to display inside the notification.</param>
+            <param name="expirationTime">The time after which the notification is closed automatically.</param>
+            <param name="onClick">Action invoked when the notification is clicked.</param>
+            <param name="onClose">Action invoked when the notification is closed.</param>
+            <param name="CloseOnClick">Whether the notification should close when clicked.</param>
+            <param name="ShowXbtn">Whether to show the close (X) button.</param>
+        </member>
         <member name="M:Notification.Wpf.Controls.NotificationArea.Show(Notifications.Wpf.ViewModels.NotificationProgressViewModel,System.Boolean)">
             <summary>
-            Отображает окно прогресса
+            Displays a progress notification.
             </summary>
-            <param name="progress">модель прогресс бара</param>
-            <param name="ShowXbtn">need to show X close button</param>
+            <param name="progress">The progress bar view model.</param>
+            <param name="ShowXbtn">Whether to show the close (X) button.</param>
         </member>
         <member name="M:Notification.Wpf.Controls.NotificationArea.OnShowContent(Notification.Wpf.Controls.Notification,System.Nullable{System.TimeSpan})">
             <summary>
-            Добавляет уведомление в список отображения
+            Adds a notification to the display list and schedules its automatic removal.
             </summary>
-            <param name="notification">уведомление</param>
-            <param name="expirationTime">время отображения</param>
-            <returns></returns>
+            <param name="notification">The notification to display.</param>
+            <param name="expirationTime">The time after which the notification is closed automatically.</param>
+            <returns>A task that completes when the notification has been shown and, if applicable, expired.</returns>
+        </member>
+        <member name="T:Notification.Wpf.Controls.Notification">
+            <summary>Represents a notification control that displays content as a toast and supports close and attach interactions.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.#ctor">
+            <summary>Initializes a new instance of the <see cref="T:Notification.Wpf.Controls.Notification"/> class.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.#ctor(System.Object,System.Boolean)">
+            <summary>Initializes a new instance of the <see cref="T:Notification.Wpf.Controls.Notification"/> class with the specified content and close button visibility.</summary>
+            <param name="content">The content to display inside the notification.</param>
+            <param name="ShowXbtn"><see langword="true"/> to show the close (X) button; otherwise, <see langword="false"/>.</param>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.OnApplyTemplate">
+            <summary>Builds the visual tree of the control, wiring up the close and attach template buttons and computing the closing animation duration.</summary>
         </member>
         <member name="F:Notification.Wpf.Controls.Notification.XbtnVisibilityProperty">
             <summary>X Button visibility</summary>
@@ -630,8 +972,133 @@
         <member name="P:Notification.Wpf.Controls.Notification.XbtnVisibility">
             <summary>X Button visibility</summary>
         </member>
+        <member name="F:Notification.Wpf.Controls.Notification.NotificationAttachInvokedEvent">
+            <summary>Identifies the routed event raised when the notification attach sequence is invoked.</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.NotificationAttachEvent">
+            <summary>Identifies the routed event raised when the notification is attached.</summary>
+        </member>
+        <member name="E:Notification.Wpf.Controls.Notification.NotificationAttachInvoked">
+            <summary>Occurs when the notification attach sequence is invoked.</summary>
+        </member>
+        <member name="E:Notification.Wpf.Controls.Notification.NotificationAttach">
+            <summary>Occurs when the notification is attached.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.GetAttachOnClick(System.Windows.DependencyObject)">
+            <summary>Gets the value of the <see cref="F:Notification.Wpf.Controls.Notification.AttachOnClickProperty"/> attached property for the specified object.</summary>
+            <param name="obj">The object from which to read the attached property value.</param>
+            <returns><see langword="true"/> if clicking the element opens the attached content; otherwise, <see langword="false"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.SetAttachOnClick(System.Windows.DependencyObject,System.Boolean)">
+            <summary>Sets the value of the <see cref="F:Notification.Wpf.Controls.Notification.AttachOnClickProperty"/> attached property for the specified object.</summary>
+            <param name="obj">The object on which to set the attached property value.</param>
+            <param name="value"><see langword="true"/> to open the attached content when the element is clicked; otherwise, <see langword="false"/>.</param>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.AttachOnClickProperty">
+            <summary>Identifies the AttachOnClick attached property, which opens a window displaying the associated <see cref="T:Notification.Wpf.NotificationContent"/> when the target button is clicked.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.Attach">
+            <summary>Attaches the notification by raising the close-invoked routed event, unless the notification is already closing.</summary>
+        </member>
+        <member name="P:Notification.Wpf.Controls.Notification.IsClosing">
+            <summary>Gets or sets a value indicating whether the notification is currently in the process of closing.</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.NotificationCloseInvokedEvent">
+            <summary>Identifies the routed event raised when the notification close sequence is invoked, before the closing animation finishes.</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.NotificationClosedEvent">
+            <summary>Identifies the routed event raised after the notification has been closed and the closing animation has completed.</summary>
+        </member>
+        <member name="E:Notification.Wpf.Controls.Notification.NotificationCloseInvoked">
+            <summary>Occurs when the notification close sequence is invoked, before the closing animation finishes.</summary>
+        </member>
+        <member name="E:Notification.Wpf.Controls.Notification.NotificationClosed">
+            <summary>Occurs after the notification has been closed and the closing animation has completed.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.GetCloseOnClick(System.Windows.DependencyObject)">
+            <summary>Gets the value of the <see cref="F:Notification.Wpf.Controls.Notification.CloseOnClickProperty"/> attached property for the specified object.</summary>
+            <param name="obj">The object from which to read the attached property value.</param>
+            <returns><see langword="true"/> if clicking the element closes the parent notification; otherwise, <see langword="false"/>.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.SetCloseOnClick(System.Windows.DependencyObject,System.Boolean)">
+            <summary>Sets the value of the <see cref="F:Notification.Wpf.Controls.Notification.CloseOnClickProperty"/> attached property for the specified object.</summary>
+            <param name="obj">The object on which to set the attached property value.</param>
+            <param name="value"><see langword="true"/> to close the parent notification when the element is clicked; otherwise, <see langword="false"/>.</param>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.CloseOnClickProperty">
+            <summary>Identifies the CloseOnClick attached property, which closes the parent notification when the target button is clicked.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.Notification.Close(System.Windows.Window)">
+            <summary>Closes the notification, raising the close events and closing the host toast window when no notifications remain.</summary>
+            <param name="overlayWindow">The optional toast overlay window that hosts the notification. When omitted, the host window is resolved automatically.</param>
+        </member>
+        <member name="T:Notification.Wpf.Controls.ProgresBarAnimateBehavior">
+            <summary>
+            Behavior that smoothly animates value changes of an attached <see cref="T:System.Windows.Controls.ProgressBar"/>.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.ProgresBarAnimateBehavior.OnAttached">
+            <summary>
+            Called when the behavior is attached to a <see cref="T:System.Windows.Controls.ProgressBar"/>; subscribes to value changes.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.ProgresBarAnimateBehavior.OnDetaching">
+            <summary>
+            Called when the behavior is detached from the <see cref="T:System.Windows.Controls.ProgressBar"/>; unsubscribes from value changes.
+            </summary>
+        </member>
+        <member name="T:Notification.Wpf.Controls.ReversibleStackPanel">
+            <summary>
+            A <see cref="T:System.Windows.Controls.StackPanel"/> that can arrange its children in reverse order.
+            </summary>
+        </member>
+        <member name="P:Notification.Wpf.Controls.ReversibleStackPanel.ReverseOrder">
+            <summary>Gets or sets a value indicating whether children are arranged in reverse order.</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.ReversibleStackPanel.ReverseOrderProperty">
+            <summary>Identifies the <see cref="P:Notification.Wpf.Controls.ReversibleStackPanel.ReverseOrder"/> dependency property.</summary>
+        </member>
+        <member name="M:Notification.Wpf.Controls.ReversibleStackPanel.ArrangeOverride(System.Windows.Size)">
+            <summary>
+            Arranges child elements, optionally in reverse order depending on <see cref="P:Notification.Wpf.Controls.ReversibleStackPanel.ReverseOrder"/>.
+            </summary>
+            <param name="arrangeSize">The size available to arrange the children.</param>
+            <returns>The actual size used by the panel.</returns>
+        </member>
         <member name="M:Notification.Wpf.Converters.ColorAlphaConverter.Convert(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
             <inheritdoc />
+        </member>
+        <member name="T:Notification.Wpf.Converters.ValueConverter">
+            <summary>
+            Base class for value converters that can also be used directly as a XAML markup extension.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Converters.ValueConverter.ProvideValue(System.IServiceProvider)">
+            <summary>
+            Returns the converter instance itself as the markup extension value.
+            </summary>
+            <param name="sp">The service provider for the markup extension.</param>
+            <returns>The current converter instance.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Converters.ValueConverter.Convert(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
+            <summary>
+            Converts a value from the source to the target.
+            </summary>
+            <param name="v">The value produced by the binding source.</param>
+            <param name="t">The type of the binding target property.</param>
+            <param name="p">The converter parameter to use.</param>
+            <param name="c">The culture to use in the converter.</param>
+            <returns>The converted value.</returns>
+        </member>
+        <member name="M:Notification.Wpf.Converters.ValueConverter.ConvertBack(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
+            <summary>
+            Converts a value from the target back to the source.
+            </summary>
+            <param name="v">The value produced by the binding target.</param>
+            <param name="t">The type to convert to.</param>
+            <param name="p">The converter parameter to use.</param>
+            <param name="c">The culture to use in the converter.</param>
+            <returns>The converted value.</returns>
         </member>
         <member name="T:Notification.Wpf.Combine">
             <summary>Конвертер, последовательно комбинирующий действия двух других конвертеров</summary>
@@ -650,6 +1117,62 @@
         </member>
         <member name="M:Notification.Wpf.StringIsNullOrWhiteSpace.Convert(System.Object,System.Type,System.Object,System.Globalization.CultureInfo)">
             <inheritdoc />
+        </member>
+        <member name="T:Notification.Wpf.DependencyInjection.WpfNotificationServiceCollectionExtensions">
+            <summary>
+            Provides extension methods for registering WPF notification services in an <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/>.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.DependencyInjection.WpfNotificationServiceCollectionExtensions.AddWpfNotifications(Microsoft.Extensions.DependencyInjection.IServiceCollection,System.Action{Notification.Core.INotificationConfiguration})">
+            <summary>
+            Registers the WPF notification manager and related services in the dependency injection container.
+            </summary>
+            <param name="services">The service collection to add the notification services to.</param>
+            <param name="configure">An optional delegate used to configure the notification options.</param>
+            <returns>The same <see cref="T:Microsoft.Extensions.DependencyInjection.IServiceCollection"/> instance so that calls can be chained.</returns>
+        </member>
+        <member name="T:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior">
+            <summary>
+            Provides attached properties that size a <see cref="T:System.Windows.Controls.TextBlock"/> by a fixed or maximum number of text lines.
+            </summary>
+        </member>
+        <member name="F:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.LinesProperty">
+            <summary>
+            Identifies the Lines attached property that sets the exact height of a <see cref="T:System.Windows.Controls.TextBlock"/> in lines.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.SetLines(System.Windows.Controls.TextBlock,System.Int32)">
+            <summary>
+            Sets the value of the Lines attached property for the specified <see cref="T:System.Windows.Controls.TextBlock"/>.
+            </summary>
+            <param name="element">The text block to set the value on.</param>
+            <param name="value">The number of lines that defines the text block height.</param>
+        </member>
+        <member name="M:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.GetLines(System.Windows.Controls.TextBlock)">
+            <summary>
+            Gets the value of the Lines attached property for the specified <see cref="T:System.Windows.Controls.TextBlock"/>.
+            </summary>
+            <param name="element">The text block to read the value from.</param>
+            <returns>The number of lines that defines the text block height.</returns>
+        </member>
+        <member name="F:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.MaxLinesProperty">
+            <summary>
+            Identifies the MaxLines attached property that sets the maximum height of a <see cref="T:System.Windows.Controls.TextBlock"/> in lines.
+            </summary>
+        </member>
+        <member name="M:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.SetMaxLines(System.Windows.Controls.TextBlock,System.Int32)">
+            <summary>
+            Sets the value of the MaxLines attached property for the specified <see cref="T:System.Windows.Controls.TextBlock"/>.
+            </summary>
+            <param name="element">The text block to set the value on.</param>
+            <param name="value">The maximum number of lines that defines the text block height.</param>
+        </member>
+        <member name="M:Notification.Wpf.Sample.Helpers.NotificationLineHeightBehavior.GetMaxLines(System.Windows.Controls.TextBlock)">
+            <summary>
+            Gets the value of the MaxLines attached property for the specified <see cref="T:System.Windows.Controls.TextBlock"/>.
+            </summary>
+            <param name="element">The text block to read the value from.</param>
+            <returns>The maximum number of lines that defines the text block height.</returns>
         </member>
         <member name="T:Notification.Wpf.Utils.ImageUtils">
             <summary>
@@ -712,22 +1235,67 @@
             NotificationProgress
             </summary>
         </member>
+        <member name="M:Notification.Wpf.View.NotificationProgress.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notification.Wpf.View.NotificationProgress"/> class.
+            </summary>
+        </member>
         <member name="M:Notification.Wpf.View.NotificationProgress.InitializeComponent">
             <summary>
             InitializeComponent
             </summary>
         </member>
+        <member name="T:Notifications.Wpf.Command.LamdaCommand">
+            <summary>
+            An <see cref="T:System.Windows.Input.ICommand"/> implementation that delegates execution and execution checks to supplied delegates.
+            </summary>
+        </member>
+        <member name="M:Notifications.Wpf.Command.LamdaCommand.CanExecute(System.Object)">
+            <summary>
+            Determines whether the command can execute in its current state.
+            </summary>
+            <param name="parameter">Data used by the command; may be <see langword="null"/>.</param>
+            <returns><see langword="true"/> if the command can execute; otherwise, <see langword="false"/>.</returns>
+        </member>
+        <member name="M:Notifications.Wpf.Command.LamdaCommand.Execute(System.Object)">
+            <summary>
+            Executes the command.
+            </summary>
+            <param name="parameter">Data used by the command; may be <see langword="null"/>.</param>
+        </member>
+        <member name="E:Notifications.Wpf.Command.LamdaCommand.CanExecuteChanged">
+            <summary>
+            Occurs when changes happen that affect whether the command should execute.
+            </summary>
+        </member>
+        <member name="M:Notifications.Wpf.Command.LamdaCommand.#ctor(System.Action{System.Object},System.Func{System.Object,System.Boolean})">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notifications.Wpf.Command.LamdaCommand"/> class.
+            </summary>
+            <param name="OnExecuteAction">The action invoked when the command is executed.</param>
+            <param name="CanExecuteFunc">The optional predicate that determines whether the command can execute.</param>
+        </member>
+        <member name="T:Notifications.Wpf.Extensions.ColumnDefinitionCollapsable">
+            <summary>
+            A <see cref="T:System.Windows.Controls.ColumnDefinition"/> that can be collapsed to zero width via the <see cref="P:Notifications.Wpf.Extensions.ColumnDefinitionCollapsable.Visible"/> property.
+            </summary>
+        </member>
         <member name="F:Notifications.Wpf.Extensions.ColumnDefinitionCollapsable.VisibleProperty">
-            <summary>Видимость</summary>
+            <summary>Identifies the <see cref="P:Notifications.Wpf.Extensions.ColumnDefinitionCollapsable.Visible"/> dependency property.</summary>
         </member>
         <member name="P:Notifications.Wpf.Extensions.ColumnDefinitionCollapsable.Visible">
-            <summary>Видимость</summary>
+            <summary>Gets or sets a value indicating whether the column is visible; when <c>false</c> the column collapses to zero width.</summary>
+        </member>
+        <member name="T:Notifications.Wpf.Extensions.RowDefinitionCollapsable">
+            <summary>
+            A <see cref="T:System.Windows.Controls.RowDefinition"/> that can be collapsed to zero height via the <see cref="P:Notifications.Wpf.Extensions.RowDefinitionCollapsable.Visible"/> property.
+            </summary>
         </member>
         <member name="F:Notifications.Wpf.Extensions.RowDefinitionCollapsable.VisibleProperty">
-            <summary>Видимость</summary>
+            <summary>Identifies the <see cref="P:Notifications.Wpf.Extensions.RowDefinitionCollapsable.Visible"/> dependency property.</summary>
         </member>
         <member name="P:Notifications.Wpf.Extensions.RowDefinitionCollapsable.Visible">
-            <summary>Видимость</summary>
+            <summary>Gets or sets a value indicating whether the row is visible; when <c>false</c> the row collapses to zero height.</summary>
         </member>
         <member name="T:Notifications.Wpf.Annotations.CanBeNullAttribute">
             <summary>
@@ -1455,6 +2023,32 @@
             marked with the <see cref="T:Notifications.Wpf.Annotations.XamlItemsControlAttribute"/> attribute.
             </remarks>
         </member>
+        <member name="T:Notifications.Wpf.ViewModels.Base.ViewModel">
+            <summary>
+            Base view model that implements <see cref="T:System.ComponentModel.INotifyPropertyChanged"/> for data-bound classes.
+            </summary>
+        </member>
+        <member name="E:Notifications.Wpf.ViewModels.Base.ViewModel.PropertyChanged">
+            <summary>
+            Occurs when a property value changes.
+            </summary>
+        </member>
+        <member name="M:Notifications.Wpf.ViewModels.Base.ViewModel.OnPropertyChanged(System.String)">
+            <summary>
+            Raises the <see cref="E:Notifications.Wpf.ViewModels.Base.ViewModel.PropertyChanged"/> event for the specified property.
+            </summary>
+            <param name="PropertyName">The name of the property that changed. Automatically supplied by the caller.</param>
+        </member>
+        <member name="M:Notifications.Wpf.ViewModels.Base.ViewModel.Set``1(``0@,``0,System.String)">
+            <summary>
+            Sets the backing field to a new value and raises <see cref="E:Notifications.Wpf.ViewModels.Base.ViewModel.PropertyChanged"/> if the value changed.
+            </summary>
+            <typeparam name="T">The type of the property value.</typeparam>
+            <param name="field">A reference to the backing field of the property.</param>
+            <param name="value">The new value to assign.</param>
+            <param name="PropertyName">The name of the property. Automatically supplied by the caller.</param>
+            <returns><c>true</c> if the value changed; otherwise, <c>false</c>.</returns>
+        </member>
         <member name="T:Notifications.Wpf.ViewModels.NotificationProgressViewModel">
             <summary>
             progress bar model
@@ -1593,6 +2187,11 @@
             </summary>
             <summary>
             TextContentView
+            </summary>
+        </member>
+        <member name="M:Notifications.Wpf.View.TextContentView.#ctor">
+            <summary>
+            Initializes a new instance of the <see cref="T:Notifications.Wpf.View.TextContentView"/> class.
             </summary>
         </member>
         <member name="M:Notifications.Wpf.View.TextContentView.InitializeComponent">

--- a/src/Notification.Wpf/Notification.Wpf.xml
+++ b/src/Notification.Wpf/Notification.Wpf.xml
@@ -515,7 +515,7 @@
         <member name="M:Notification.Wpf.NotificationManager.ShowButtonWindow(System.String,System.String,System.Action,System.String,System.Action,System.String,System.Nullable{System.TimeSpan},System.String,Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions,Notification.Wpf.Classes.NotificationImage,System.Boolean)">
             <inheritdoc />
         </member>
-        <member name="M:Notification.Wpf.NotificationManager.ShowContent(System.Object,System.Nullable{System.TimeSpan},System.String,System.Action,System.Action,System.Boolean,System.Boolean)">
+        <member name="M:Notification.Wpf.NotificationManager.ShowContent(System.Object,System.Nullable{System.TimeSpan},System.String,System.Action,System.Action,System.Boolean,System.Boolean,System.Action{Notification.Wpf.Controls.Notification})">
             <summary>
             Запуск отображения в зависимости от типа контента
             </summary>
@@ -526,6 +526,7 @@
             <param name="onClose">действие при закрытии</param>
             <param name="CloseOnClick">Закрыть сообщение при клике по телу</param>
             <param name="ShowXbtn">Show X (close) btn</param>
+            <param name="onCreated">Optional callback invoked with each created notification, used to register a programmatic dismiss handle.</param>
         </member>
         <member name="M:Notification.Wpf.NotificationManager.Show(Notification.Core.NotificationRequest)">
             <inheritdoc />
@@ -624,6 +625,9 @@
         </member>
         <member name="P:Notification.Wpf.NotificationContent.CloseOnClick">
             <inheritdoc/>
+        </member>
+        <member name="P:Notification.Wpf.NotificationContent.RightClickAction">
+            <summary> Action invoked when the notification is right-clicked (issue #54). </summary>
         </member>
         <member name="M:Notification.Wpf.NotificationContent.GetValidContent(System.String,System.String,Notification.Core.NotificationType,System.Action,System.Object,System.Action,System.Object,Notification.Wpf.Classes.NotificationImage,System.Boolean,Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions)">
             <summary> Get valid options after check for null </summary>
@@ -838,6 +842,15 @@
         <member name="P:Notification.Wpf.Constants.NotificationConstants.MessagePosition">
             <summary> Overlay message position </summary>
         </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.OverlayWindowTopmost">
+            <summary> Whether the notification overlay window stays on top of other windows (issue #65) </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.KeepNotificationVisibleOnMouseOver">
+            <summary> Pause the auto-close timer while the mouse is over the notification (issue #71) </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.NotificationCornerRadius">
+            <summary> Corner radius of the notification card (issue #52) </summary>
+        </member>
         <member name="P:Notification.Wpf.Constants.NotificationConstants.IsReversedPanel">
             <summary> Reverse are when absolute </summary>
         </member>
@@ -964,7 +977,7 @@
             Resolves template parts and initializes the reversed layout state after the template is applied.
             </summary>
         </member>
-        <member name="M:Notification.Wpf.Controls.NotificationArea.Show(System.Object,System.TimeSpan,System.Action,System.Action,System.Boolean,System.Boolean)">
+        <member name="M:Notification.Wpf.Controls.NotificationArea.Show(System.Object,System.TimeSpan,System.Action,System.Action,System.Boolean,System.Boolean,System.Action{Notification.Wpf.Controls.Notification})">
             <summary>
             Displays a notification with the specified content.
             </summary>
@@ -974,6 +987,7 @@
             <param name="onClose">Action invoked when the notification is closed.</param>
             <param name="CloseOnClick">Whether the notification should close when clicked.</param>
             <param name="ShowXbtn">Whether to show the close (X) button.</param>
+            <param name="onCreated">Optional callback invoked with the created notification, used to register a programmatic dismiss handle.</param>
         </member>
         <member name="M:Notification.Wpf.Controls.NotificationArea.Show(Notifications.Wpf.ViewModels.NotificationProgressViewModel,System.Boolean)">
             <summary>
@@ -1009,6 +1023,12 @@
         </member>
         <member name="P:Notification.Wpf.Controls.Notification.XbtnVisibility">
             <summary>X Button visibility</summary>
+        </member>
+        <member name="F:Notification.Wpf.Controls.Notification.CornerRadiusProperty">
+            <summary>Identifies the <see cref="P:Notification.Wpf.Controls.Notification.CornerRadius"/> dependency property.</summary>
+        </member>
+        <member name="P:Notification.Wpf.Controls.Notification.CornerRadius">
+            <summary>Gets or sets the corner radius of the notification card.</summary>
         </member>
         <member name="F:Notification.Wpf.Controls.Notification.NotificationAttachInvokedEvent">
             <summary>Identifies the routed event raised when the notification attach sequence is invoked.</summary>

--- a/src/Notification.Wpf/Themes/Generic.xaml
+++ b/src/Notification.Wpf/Themes/Generic.xaml
@@ -156,7 +156,11 @@
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="Button">
-                    <ContentControl DockPanel.Dock="Top" Content="{StaticResource CloseIcon}"/>
+                    <!-- Close icon follows the button Foreground so it can be styled per notification (issue #53). -->
+                    <Viewbox Height="12" DockPanel.Dock="Top">
+                        <Path Data="M464 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm0 394c0 3.3-2.7 6-6 6H54c-3.3 0-6-2.7-6-6V86c0-3.3 2.7-6 6-6h404c3.3 0 6 2.7 6 6v340zM356.5 194.6L295.1 256l61.4 61.4c4.6 4.6 4.6 12.1 0 16.8l-22.3 22.3c-4.6 4.6-12.1 4.6-16.8 0L256 295.1l-61.4 61.4c-4.6 4.6-12.1 4.6-16.8 0l-22.3-22.3c-4.6-4.6-4.6-12.1 0-16.8l61.4-61.4-61.4-61.4c-4.6-4.6-4.6-12.1 0-16.8l22.3-22.3c4.6-4.6 12.1-4.6 16.8 0l61.4 61.4 61.4-61.4c4.6-4.6 12.1-4.6 16.8 0l22.3 22.3c4.7 4.6 4.7 12.1 0 16.8z"
+                              Fill="{TemplateBinding Foreground}"/>
+                    </Viewbox>
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
@@ -208,7 +212,8 @@
                 </Border>
             </DataTemplate>
             <DataTemplate DataType="{x:Type wpf:NotificationContent}" x:Key="DefaultNotificationTemplate">
-                <Border x:Name="Border" Padding="12">
+                <Border x:Name="Border" Padding="12"
+                        CornerRadius="{Binding CornerRadius, RelativeSource={RelativeSource AncestorType=controls:Notification}}">
                     <Grid>
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto"/>
@@ -387,6 +392,7 @@
         <Border Background="{TemplateBinding Background}"
                 BorderBrush="{TemplateBinding BorderBrush}"
                 BorderThickness="{TemplateBinding BorderThickness}"
+                CornerRadius="{TemplateBinding CornerRadius}"
                 Margin="8,8,0,0">
             <Grid>
                 <ContentPresenter/>

--- a/src/Notification.Wpf/View/NotificationProgress.xaml.cs
+++ b/src/Notification.Wpf/View/NotificationProgress.xaml.cs
@@ -7,6 +7,9 @@ namespace Notification.Wpf.View
     /// </summary>
     public partial class NotificationProgress : UserControl
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NotificationProgress"/> class.
+        /// </summary>
         public NotificationProgress() => InitializeComponent();
     }
 }

--- a/src/Notification.Wpf/View/TextContentView.xaml.cs
+++ b/src/Notification.Wpf/View/TextContentView.xaml.cs
@@ -8,6 +8,9 @@ namespace Notifications.Wpf.View
     /// </summary>
     public partial class TextContentView : UserControl
     {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="TextContentView"/> class.
+        /// </summary>
         public TextContentView()
         {
             InitializeComponent();

--- a/src/Notification.Wpf/ViewModels/Base/ViewModel.cs
+++ b/src/Notification.Wpf/ViewModels/Base/ViewModel.cs
@@ -4,13 +4,31 @@ using Notifications.Wpf.Annotations;
 
 namespace Notifications.Wpf.ViewModels.Base
 {
+    /// <summary>
+    /// Base view model that implements <see cref="INotifyPropertyChanged"/> for data-bound classes.
+    /// </summary>
     public abstract class ViewModel : INotifyPropertyChanged
     {
+        /// <summary>
+        /// Occurs when a property value changes.
+        /// </summary>
         public event PropertyChangedEventHandler PropertyChanged;
 
+        /// <summary>
+        /// Raises the <see cref="PropertyChanged"/> event for the specified property.
+        /// </summary>
+        /// <param name="PropertyName">The name of the property that changed. Automatically supplied by the caller.</param>
         [NotifyPropertyChangedInvocator]
         protected virtual void OnPropertyChanged([CallerMemberName] string PropertyName = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(PropertyName));
 
+        /// <summary>
+        /// Sets the backing field to a new value and raises <see cref="PropertyChanged"/> if the value changed.
+        /// </summary>
+        /// <typeparam name="T">The type of the property value.</typeparam>
+        /// <param name="field">A reference to the backing field of the property.</param>
+        /// <param name="value">The new value to assign.</param>
+        /// <param name="PropertyName">The name of the property. Automatically supplied by the caller.</param>
+        /// <returns><c>true</c> if the value changed; otherwise, <c>false</c>.</returns>
         [NotifyPropertyChangedInvocator]
         protected virtual bool Set<T>(ref T field, T value, [CallerMemberName] string PropertyName = null)
         {


### PR DESCRIPTION
## Summary — v10.0.0

This release modernizes the public API, fixes a batch of long-standing issues and overhauls the documentation. **Full backward compatibility is preserved** — existing code keeps compiling and running.

### API
- **Tuple-free progress API** — `Report(value)`, `Report(value, message)`, `Report(value, message, title)`, `ReportIndeterminate(...)` overloads; `NotificationProgressReport.Indeterminate(...)` factory and `With*` helpers. Tuple-based `GetProgress<T>` / `GetSlowedProgress<T>` marked `[Obsolete]` with non-tuple replacements (`GetSlowedProgress(int)`, `GetValueProgress`, `GetSlowedValueProgress`).
- **`ShowProgressBar(ProgressBarOptions)`** — replaces the 16-parameter positional overload (now `[Obsolete]`).
- **`NotificationBuilder.WithContent` / `NotificationRequest.Content`** — custom content through the Builder API.
- All 5 packages aligned to version `10.0.0.0`.

### Documentation
- New [Migration Guide](https://github.com/Platonenkov/Notification.Wpf/blob/dev/Migration.md) with before/after examples and parameter-mapping tables.
- Full XML documentation across Core, Console, Avalonia, MAUI and WPF.
- Documented new WPF behavior settings and right-click action.

### CI
- New test pipeline on push/PR to `dev`/`master`; `concurrency` cancellation on all workflows; MAUI workloads added to the docs pipeline.

## Issue fixes

Closes #48 — `Dismiss(Guid)` / `DismissAll()` now actually close the target notification.
Closes #52 — `Notification.CornerRadius` dependency property and `NotificationConstants.NotificationCornerRadius`.
Closes #53 — close icon follows the notification `Foreground`; programmatic close via `Dismiss`.
Closes #54 — right-click support (`OnRightClick` / `RightClickAction`).
Closes #65 — `NotificationConstants.OverlayWindowTopmost`.
Closes #66 — fixed the `InvalidOperationException` race in `ShowContent` (overlay window mid-close).
Closes #71 — `NotificationConstants.KeepNotificationVisibleOnMouseOver` pauses the auto-close timer on mouse-over.

## Test plan

- [x] `dotnet build` — all 5 packages, all TFM (net10/9/8/4.8) — 0 errors, 0 warnings
- [x] Core / Console / WPF unit tests pass
- [x] WPF and Avalonia sample apps build
- [ ] Visual smoke test of the WPF sample (toasts, progress, buttons, custom content)
- [ ] NuGet packages produced by `dotnet pack`