### PR TITLE
fix: rename Avalonia NuGet package id to Notification.AvaloniaUI

### DIFF
--- a/DocFx/index.md
+++ b/DocFx/index.md
@@ -9,7 +9,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 | **Notification.Core** | `netstandard2.0` | Platform-agnostic core: interfaces, Builder API, events, queue, DI |
 | **Notification.Wpf** | `net10/9/8/4.8-windows` | WPF implementation with full UI: toasts, progress bars, custom content |
 | **Notification.Console** | `netstandard2.0` | Console implementation with colored terminal output |
-| **Notification.Avalonia** | `net8.0` | Avalonia UI implementation via WindowNotificationManager |
+| **Notification.AvaloniaUI** | `net8.0` | Avalonia UI implementation via WindowNotificationManager |
 | **Notification.Maui** | `net10.0-*` | .NET MAUI implementation via CommunityToolkit Snackbar |
 
 ## Installation
@@ -23,7 +23,7 @@ Install-Package Notification.Core
 
 // Platform-specific
 Install-Package Notification.Console
-Install-Package Notification.Avalonia
+Install-Package Notification.AvaloniaUI
 Install-Package Notification.Maui
 ```
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 | **Notification.Core** | `netstandard2.0` | Platform-agnostic core: interfaces, Builder API, events, queue, DI |
 | **Notification.Wpf** | `net10/9/8/4.8-windows` | WPF implementation with full UI: toasts, progress bars, custom content |
 | **Notification.Console** | `netstandard2.0` | Console implementation with colored terminal output |
-| **Notification.Avalonia** | `net8.0` | Avalonia UI implementation via WindowNotificationManager |
+| **Notification.AvaloniaUI** | `net8.0` | Avalonia UI implementation via WindowNotificationManager |
 | **Notification.Maui** | `net10.0-*` | .NET MAUI implementation via CommunityToolkit Snackbar |
 
 ## Installation
@@ -26,7 +26,7 @@ Install-Package Notification.Core
 
 // Platform-specific
 Install-Package Notification.Console
-Install-Package Notification.Avalonia
+Install-Package Notification.AvaloniaUI
 Install-Package Notification.Maui
 ```
 

--- a/src/Notification.Avalonia/Notification.Avalonia.csproj
+++ b/src/Notification.Avalonia/Notification.Avalonia.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <Version>10.0.0.0</Version>
+    <!-- NuGet id differs from the assembly name: "Notification.Avalonia" is already taken on NuGet.org. -->
+    <PackageId>Notification.AvaloniaUI</PackageId>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Avalonia UI implementation of Notification.Core - cross-platform desktop toast notifications</Description>


### PR DESCRIPTION
## Problem

The v10.0.0 release (PR #76) failed at the **Publish NuGet.org** step with `403 Forbidden`:

```
error: 403 (The specified API key is invalid, has expired, or does not have permission
       to access the specified package.)
```

Root cause: the package id **`Notification.Avalonia`** is **already taken on NuGet.org** by an unrelated package — [AvaloniaCommunity/Avalonia.Notification](https://github.com/AvaloniaCommunity/Avalonia.Notification) (owner `Larymar`, ~40k downloads). `dotnet nuget push` fails on it first (alphabetical order) and stops, so **none** of the 5 packages reach NuGet.org.

The API key itself is fine (not expired, glob `*`, "Push new packages and package versions"). The other ids — `Notification.Core`, `Notification.Console`, `Notification.Maui` — are free, and `Notification.Wpf` is already owned by `APlatonenkov`.

## Fix

Set `<PackageId>Notification.AvaloniaUI</PackageId>` in `Notification.Avalonia.csproj`. Only the **NuGet package id** changes — the assembly name and namespace stay `Notification.Avalonia`, so there are no code or API changes. Install/package-name references in `README.md` and `DocFx/index.md` updated accordingly.

## After merge

`Publish.yml` re-runs on `master` and publishes all 5 packages: `Notification.Core`, `Notification.Wpf`, `Notification.Console`, `Notification.AvaloniaUI`, `Notification.Maui`.