### PR TITLE
ci: make symbol package push best-effort in Publish.yml

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -67,12 +67,20 @@ jobs:
       - name: Pack MAUI
         run: dotnet pack src/Notification.Maui/Notification.Maui.csproj -c Release --no-build
 
-      - name: Publish GitHub
-        run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
-          dotnet nuget push "**/*.snupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
+      - name: Publish GitHub (packages)
+        run: dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish NuGet
-        run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
-          dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
+      # Symbol packages are best-effort: a brand-new package id is still validating
+      # right after its first push, so its .snupkg cannot be attached yet.
+      - name: Publish GitHub (symbols)
+        continue-on-error: true
+        run: dotnet nuget push "**/*.snupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish NuGet (packages)
+        run: dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
+
+      # Symbol packages are best-effort — see the note above. Re-run the job later
+      # (once new packages finish validation) to push any symbols skipped here.
+      - name: Publish NuGet (symbols)
+        continue-on-error: true
+        run: dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}


### PR DESCRIPTION
## Problem

The v10 release succeeded — all 5 packages reached NuGet.org — but the **Publish NuGet.org** job was still marked ❌:

```
error: 404 (A package with ID 'Notification.Core' and version '10.0.0' does not exist.
       Please upload the package before uploading its symbols.)
```

A **brand-new package id** (`Notification.Core`) is still in NuGet.org's validation pipeline for a few minutes after its first push, so its `.snupkg` (debug symbols) cannot be attached yet. The package push itself succeeded — only the symbol push failed, and that failed the whole job.

## Fix

Each publish step is split into a **packages** step and a **symbols** step. The `.snupkg` push now uses `continue-on-error: true`:

- A real `.nupkg` push failure still fails the job (as it should).
- A transient symbol-push failure (new package still validating) no longer fails the release workflow.

Skipped symbols can be pushed by simply re-running the job later (`--skip-duplicate` makes the `.nupkg` re-push a no-op).

This applies to both the GitHub Packages and the NuGet.org publish steps.