### PR TITLE
fix: rename Core to Notification.CoreUI, bump all to 10.0.1

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -67,12 +67,20 @@ jobs:
       - name: Pack MAUI
         run: dotnet pack src/Notification.Maui/Notification.Maui.csproj -c Release --no-build
 
-      - name: Publish GitHub
-        run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
-          dotnet nuget push "**/*.snupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{secrets.GITHUB_TOKEN}}
+      - name: Publish GitHub (packages)
+        run: dotnet nuget push "**/*.nupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Publish NuGet
-        run: |
-          dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
-          dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
+      # Symbol packages are best-effort: a brand-new package id is still validating
+      # right after its first push, so its .snupkg cannot be attached yet.
+      - name: Publish GitHub (symbols)
+        continue-on-error: true
+        run: dotnet nuget push "**/*.snupkg" --skip-duplicate --source https://nuget.pkg.github.com/Platonenkov/index.json -k ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Publish NuGet (packages)
+        run: dotnet nuget push "**/*.nupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}
+
+      # Symbol packages are best-effort — see the note above. Re-run the job later
+      # (once new packages finish validation) to push any symbols skipped here.
+      - name: Publish NuGet (symbols)
+        continue-on-error: true
+        run: dotnet nuget push "**/*.snupkg" --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{ secrets.NUGETAPIKEY }}

--- a/DocFx/Getting-Started.md
+++ b/DocFx/Getting-Started.md
@@ -7,7 +7,7 @@
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console

--- a/DocFx/index.md
+++ b/DocFx/index.md
@@ -19,7 +19,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console

--- a/src/Notification.Avalonia/Notification.Avalonia.csproj
+++ b/src/Notification.Avalonia/Notification.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <!-- NuGet id differs from the assembly name: "Notification.Avalonia" is already taken on NuGet.org. -->
     <PackageId>Notification.AvaloniaUI</PackageId>
     <IsPackable>true</IsPackable>

--- a/src/Notification.Console/Notification.Console.csproj
+++ b/src/Notification.Console/Notification.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Console implementation of Notification.Core - colored terminal notifications with progress bars</Description>

--- a/src/Notification.Core/Notification.Core.csproj
+++ b/src/Notification.Core/Notification.Core.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
+    <!-- NuGet id differs from the assembly name: "Notification.Core" is too generic and may conflict with reserved prefixes. -->
+    <PackageId>Notification.CoreUI</PackageId>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Notification.Wpf\Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/Notification.Maui/Notification.Maui.csproj
+++ b/src/Notification.Maui/Notification.Maui.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>

--- a/src/Notification.Maui/Notification.Maui.xml
+++ b/src/Notification.Maui/Notification.Maui.xml
@@ -61,6 +61,12 @@
             <param name="configure">An optional delegate to configure the notification settings.</param>
             <returns>The same application builder instance for chaining.</returns>
         </member>
+        <member name="T:Notification.Maui.Resource">
+            <summary>
+            Android Resource Designer class.
+            Exposes the Android Resource designer assembly into the project Namespace.
+            </summary>
+        </member>
         <member name="M:Microsoft.Maui.Controls.ColorAnimationExtensions_Button.TextColorTo(Microsoft.Maui.Controls.Button,Microsoft.Maui.Graphics.Color,System.UInt32,System.UInt32,Microsoft.Maui.Easing,System.Threading.CancellationToken)">
             <summary>
             Animates the TextColor of an <see cref = "T:Microsoft.Maui.ITextStyle"/> to the given color

--- a/src/Notification.Wpf/Notification.Wpf.csproj
+++ b/src/Notification.Wpf/Notification.Wpf.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows;net4.8-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>


### PR DESCRIPTION
## Summary
- Rename Core NuGet PackageId from `Notification.Core` to `Notification.CoreUI` — the old ID was never published to NuGet.org (validation/prefix conflict), breaking all 10.0.0 packages that depended on it
- Bump all package versions to **10.0.1** so NuGet.org gets working packages with correct dependency
- Make symbol package push best-effort (`continue-on-error: true`) in Publish.yml

## Packages affected
| Package | 10.0.0 | 10.0.1 |
|---------|--------|--------|
| Notification.CoreUI | never published | new |
| Notification.Wpf | depends on non-existent `Notification.Core` | depends on `Notification.CoreUI` |
| Notification.Console | same | fixed |
| Notification.AvaloniaUI | same | fixed |
| Notification.Maui | same | fixed |

## After merge
Unlist broken 10.0.0 versions on nuget.org for Wpf, Console, AvaloniaUI, Maui.