### PR TITLE
fix: rename Core to Notification.CoreUI, bump 10.0.1, update docs (#80)

### DIFF
--- a/DocFx/Getting-Started.md
+++ b/DocFx/Getting-Started.md
@@ -7,7 +7,7 @@
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console
@@ -98,12 +98,7 @@ public static MauiApp CreateMauiApp()
     MauiAppBuilder builder = MauiApp.CreateBuilder();
     builder
         .UseMauiApp<App>()
-        .UseMauiCommunityToolkit(options =>
-        {
-#if WINDOWS
-            options.SetShouldEnableSnackbarOnWindows(true);
-#endif
-        })
+        .UseMauiCommunityToolkit()    // required by Notification.Maui
         .UseMauiNotifications(config =>
         {
             config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
@@ -112,6 +107,11 @@ public static MauiApp CreateMauiApp()
     return builder.Build();
 }
 ```
+
+> **Windows Snackbar:** if you need Snackbar (action buttons) on Windows,
+> add `options.SetShouldEnableSnackbarOnWindows(true)` inside `.UseMauiCommunityToolkit(options => { ... })`.
+> This may cause "No COM servers are registered" in Blazor Hybrid or unpackaged apps.
+> Without this option, simple Toast notifications still work on all platforms.
 
 ## WPF — Static API (no DI)
 

--- a/DocFx/index.md
+++ b/DocFx/index.md
@@ -19,7 +19,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console
@@ -75,10 +75,12 @@ services.AddConsoleNotifications();
 services.AddAvaloniaNotifications();
 
 // MAUI (in MauiProgram.cs)
-builder.UseMauiNotifications(config =>
-{
-    config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
-});
+builder
+    .UseMauiCommunityToolkit()    // required by Notification.Maui
+    .UseMauiNotifications(config =>
+    {
+        config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
+    });
 ```
 
 ## WPF — Classic API (backward compatible)

--- a/Documentation.md
+++ b/Documentation.md
@@ -176,12 +176,7 @@ public static MauiApp CreateMauiApp()
     MauiAppBuilder builder = MauiApp.CreateBuilder();
     builder
         .UseMauiApp<App>()
-        .UseMauiCommunityToolkit(options =>
-        {
-#if WINDOWS
-            options.SetShouldEnableSnackbarOnWindows(true);
-#endif
-        })
+        .UseMauiCommunityToolkit()    // required by Notification.Maui
         .UseMauiNotifications(config =>
         {
             config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
@@ -190,6 +185,12 @@ public static MauiApp CreateMauiApp()
     return builder.Build();
 }
 ```
+
+> **Windows Snackbar:** CommunityToolkit.Maui Snackbar on Windows uses native `AppNotification`
+> which requires COM server registration. If you need Snackbar (action buttons) on Windows,
+> add `options.SetShouldEnableSnackbarOnWindows(true)` inside `.UseMauiCommunityToolkit(options => { ... })`.
+> Note: this may cause "No COM servers are registered for this app" in Blazor Hybrid or
+> unpackaged apps. Without this option, simple Toast notifications still work on all platforms.
 
 ### Avalonia
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Cross-platform toast notifications library for .NET. Messages, progress bars, Bu
 Install-Package Notification.Wpf
 
 // Or use Core directly for cross-platform
-Install-Package Notification.Core
+Install-Package Notification.CoreUI
 
 // Platform-specific
 Install-Package Notification.Console
@@ -79,10 +79,12 @@ services.AddConsoleNotifications();
 services.AddAvaloniaNotifications();
 
 // MAUI (in MauiProgram.cs)
-builder.UseMauiNotifications(config =>
-{
-    config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
-});
+builder
+    .UseMauiCommunityToolkit()    // required by Notification.Maui
+    .UseMauiNotifications(config =>
+    {
+        config.DefaultExpirationTime = TimeSpan.FromSeconds(3);
+    });
 ```
 
 ## Lifecycle Events

--- a/Tests/Notification.Console.Tests/Notification.Console.Tests.csproj
+++ b/Tests/Notification.Console.Tests/Notification.Console.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Notification.Core.Tests/Notification.Core.Tests.csproj
+++ b/Tests/Notification.Core.Tests/Notification.Core.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj
+++ b/Tests/Notification.Wpf.Tests/Notification.Wpf.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
-    <PackageReference Include="xunit" Version="2.*" />
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Notification.Avalonia/Notification.Avalonia.csproj
+++ b/src/Notification.Avalonia/Notification.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <!-- NuGet id differs from the assembly name: "Notification.Avalonia" is already taken on NuGet.org. -->
     <PackageId>Notification.AvaloniaUI</PackageId>
     <IsPackable>true</IsPackable>

--- a/src/Notification.Console/Notification.Console.csproj
+++ b/src/Notification.Console/Notification.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Console implementation of Notification.Core - colored terminal notifications with progress bars</Description>

--- a/src/Notification.Core/Notification.Core.csproj
+++ b/src/Notification.Core/Notification.Core.csproj
@@ -3,7 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
+    <!-- NuGet id differs from the assembly name: "Notification.Core" is too generic and may conflict with reserved prefixes. -->
+    <PackageId>Notification.CoreUI</PackageId>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\Notification.Wpf\Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/Notification.Maui/Notification.Maui.csproj
+++ b/src/Notification.Maui/Notification.Maui.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>

--- a/src/Notification.Maui/Notification.Maui.xml
+++ b/src/Notification.Maui/Notification.Maui.xml
@@ -61,6 +61,12 @@
             <param name="configure">An optional delegate to configure the notification settings.</param>
             <returns>The same application builder instance for chaining.</returns>
         </member>
+        <member name="T:Notification.Maui.Resource">
+            <summary>
+            Android Resource Designer class.
+            Exposes the Android Resource designer assembly into the project Namespace.
+            </summary>
+        </member>
         <member name="M:Microsoft.Maui.Controls.ColorAnimationExtensions_Button.TextColorTo(Microsoft.Maui.Controls.Button,Microsoft.Maui.Graphics.Color,System.UInt32,System.UInt32,Microsoft.Maui.Easing,System.Threading.CancellationToken)">
             <summary>
             Animates the TextColor of an <see cref = "T:Microsoft.Maui.ITextStyle"/> to the given color

--- a/src/Notification.Wpf/Notification.Wpf.csproj
+++ b/src/Notification.Wpf/Notification.Wpf.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows;net4.8-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.0.0</Version>
+    <Version>10.0.1.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>


### PR DESCRIPTION
* fix: rename Core NuGet package to Notification.CoreUI and bump all to 10.0.1

Notification.Core was never published to NuGet.org (ID conflict/validation failure), so all 10.0.0 packages that depended on it are broken.

- Rename Core PackageId to Notification.CoreUI (assembly name unchanged)
- Bump all package versions to 10.0.1
- Update install instructions in docs

* docs: add UseMauiCommunityToolkit to MAUI DI examples

Also migrate test projects from xunit 2.x to xunit.v3 3.2.2.

* docs: simplify MAUI setup, warn about Windows Snackbar COM issue

Remove SetShouldEnableSnackbarOnWindows from default examples — it causes COM registration errors in Blazor Hybrid and unpackaged apps. Add notes explaining when and how to enable it.