### PR TITLE
feat: colorable type icons by status (#82)

### DIFF
--- a/Samples/Notification.Wpf.Sample/ViewModels/SampleWindowViewModel.cs
+++ b/Samples/Notification.Wpf.Sample/ViewModels/SampleWindowViewModel.cs
@@ -124,9 +124,10 @@ namespace Notification.Wpf.Sample.ViewModels
                 RightButtonContent = RightButtonText ?? NotificationConstants.DefaultRightButtonContent,
 
 
-                Background = isNone ? new SolidColorBrush(ContentBackground) : null,
+                Background = isNone || UseCustomBackground ? new SolidColorBrush(ContentBackground) : null,
                 Foreground = isNone ? new SolidColorBrush(ContentForeground) : null,
                 Icon = GetIcon(isProgress),
+                IconForeground = UseIconColor ? new SolidColorBrush(IconForeground) : null,
                 MessageTextSettings = MessageSettingModel.IsActive ? MessageSettingModel.TextSetting : null,
                 TitleTextSettings = TitleSettingModel.IsActive ? TitleSettingModel.TextSetting : null,
                 RowsCount = RowCount is { } count and > 0 ? count : 1,
@@ -821,6 +822,24 @@ namespace Notification.Wpf.Sample.ViewModels
 
         #endregion
 
+        #region UseIconColor : bool - Apply the icon color to the built-in type icon (issue #82)
+
+        /// <summary>Apply the icon color to the built-in type icon</summary>
+        private bool _UseIconColor;
+
+        /// <summary>Apply the icon color to the built-in type icon</summary>
+        public bool UseIconColor
+        {
+            get => _UseIconColor;
+            set
+            {
+                Set(ref _UseIconColor, value);
+                SetContent();
+            }
+        }
+
+        #endregion
+
         private static IEnumerable<SvgAwesome> GetIcons()
         {
             var icons = Enum.GetValues<EFontAwesomeIcon>().Select(s => new SvgAwesome() { Icon = s, Height = 20 });
@@ -901,6 +920,24 @@ namespace Notification.Wpf.Sample.ViewModels
             set
             {
                 Set(ref _ContentBackground, value);
+                SetContent();
+            }
+        }
+
+        #endregion
+
+        #region UseCustomBackground : bool - Apply the background color even to typed notifications
+
+        /// <summary>Apply the background color even to typed notifications</summary>
+        private bool _UseCustomBackground;
+
+        /// <summary>Apply the background color even to typed notifications</summary>
+        public bool UseCustomBackground
+        {
+            get => _UseCustomBackground;
+            set
+            {
+                Set(ref _UseCustomBackground, value);
                 SetContent();
             }
         }

--- a/Samples/Notification.Wpf.Sample/Views/SampleWindow.xaml
+++ b/Samples/Notification.Wpf.Sample/Views/SampleWindow.xaml
@@ -295,7 +295,12 @@
                         <!--<xctk:ColorSpectrumSlider/>-->
 
                         <GroupBox Header="Background">
-                            <xctk:ColorCanvas SelectedColor="{Binding ContentBackground}"/>
+                            <StackPanel>
+                                <CheckBox Content="Override type background"
+                                          IsChecked="{Binding UseCustomBackground}"
+                                          ToolTip="Apply this background even to typed notifications — lets you pair a neutral background with a colored icon (issue #82)."/>
+                                <xctk:ColorCanvas SelectedColor="{Binding ContentBackground}"/>
+                            </StackPanel>
                         </GroupBox>
                         <GroupBox Header="Foreground">
                             <xctk:ColorCanvas SelectedColor="{Binding ContentForeground}"/>
@@ -304,7 +309,12 @@
                             <xctk:ColorCanvas SelectedColor="{Binding ProgressColor}"/>
                         </GroupBox>
                         <GroupBox Header="Icon foreground">
-                            <xctk:ColorCanvas SelectedColor="{Binding IconForeground}"/>
+                            <StackPanel>
+                                <CheckBox Content="Use icon color (issue #82)"
+                                          IsChecked="{Binding UseIconColor}"
+                                          ToolTip="Tint the built-in type icon. Choose a notification type and leave the FontAwesome list unselected so the built-in type icon is shown."/>
+                                <xctk:ColorCanvas SelectedColor="{Binding IconForeground}"/>
+                            </StackPanel>
                         </GroupBox>
                     </StackPanel>
                 </GroupBox>

--- a/Updates.md
+++ b/Updates.md
@@ -1,5 +1,14 @@
 ### Update list
 
+`v10.1.0`
+* **#82:** colorable type icons — the built-in Success / Warning / Error / Information icons can now be tinted by status
+* **Config:** added `DefaultIconColor`, `SuccessIconColor`, `WarningIconColor`, `ErrorIconColor`, `InformationIconColor` to `INotificationConfiguration` / `NotificationConfiguration` (all default to white — out-of-the-box appearance unchanged)
+* **WPF:** added `IconForeground` to `NotificationContent` / `ICustomizedOptions` for per-notification icon color
+* **Core:** added `NotificationRequest.IconColor`
+* **Sample:** added "Use icon color" and "Override type background" toggles to the WPF sample
+* All packages aligned to version `10.1.0.0`
+* Full backward compatibility — all existing APIs keep working
+
 `v10.0.0`
 * **Progress API:** added tuple-free `Report(value)`, `Report(value, message)`, `Report(value, message, title)` and `ReportIndeterminate(...)` overloads
 * **Progress API:** added `NotificationProgressReport.Indeterminate(...)` factory and `WithValue`/`WithMessage`/`WithTitle`/`WithShowCancel` helpers

--- a/src/Notification.Avalonia/Notification.Avalonia.csproj
+++ b/src/Notification.Avalonia/Notification.Avalonia.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.1.0</Version>
+    <Version>10.1.0.0</Version>
     <!-- NuGet id differs from the assembly name: "Notification.Avalonia" is already taken on NuGet.org. -->
     <PackageId>Notification.AvaloniaUI</PackageId>
     <IsPackable>true</IsPackable>

--- a/src/Notification.Console/Notification.Console.csproj
+++ b/src/Notification.Console/Notification.Console.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.1.0</Version>
+    <Version>10.1.0.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Description>Console implementation of Notification.Core - colored terminal notifications with progress bars</Description>

--- a/src/Notification.Core/Configuration/NotificationConfiguration.cs
+++ b/src/Notification.Core/Configuration/NotificationConfiguration.cs
@@ -73,6 +73,36 @@ namespace Notification.Core
         public NotificationColor InformationBackgroundColor { get; set; } = NotificationColor.CornflowerBlue;
 
         /// <summary>
+        /// Gets or sets the color of the built-in icon for notifications without a specific type.
+        /// Defaults to white so the out-of-the-box appearance is unchanged.
+        /// </summary>
+        public NotificationColor DefaultIconColor { get; set; } = NotificationColor.White;
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for success notifications.
+        /// Defaults to white so the out-of-the-box appearance is unchanged.
+        /// </summary>
+        public NotificationColor SuccessIconColor { get; set; } = NotificationColor.White;
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for warning notifications.
+        /// Defaults to white so the out-of-the-box appearance is unchanged.
+        /// </summary>
+        public NotificationColor WarningIconColor { get; set; } = NotificationColor.White;
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for error notifications.
+        /// Defaults to white so the out-of-the-box appearance is unchanged.
+        /// </summary>
+        public NotificationColor ErrorIconColor { get; set; } = NotificationColor.White;
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for information notifications.
+        /// Defaults to white so the out-of-the-box appearance is unchanged.
+        /// </summary>
+        public NotificationColor InformationIconColor { get; set; } = NotificationColor.White;
+
+        /// <summary>
         /// Gets or sets the default color for progress bar indicators.
         /// </summary>
         public NotificationColor DefaultProgressColor { get; set; } = NotificationColor.Green;

--- a/src/Notification.Core/Interfaces/INotificationConfiguration.cs
+++ b/src/Notification.Core/Interfaces/INotificationConfiguration.cs
@@ -73,6 +73,31 @@ namespace Notification.Core
         NotificationColor InformationBackgroundColor { get; set; }
 
         /// <summary>
+        /// Gets or sets the color of the built-in icon for notifications without a specific type.
+        /// </summary>
+        NotificationColor DefaultIconColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for success notifications.
+        /// </summary>
+        NotificationColor SuccessIconColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for warning notifications.
+        /// </summary>
+        NotificationColor WarningIconColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for error notifications.
+        /// </summary>
+        NotificationColor ErrorIconColor { get; set; }
+
+        /// <summary>
+        /// Gets or sets the color of the built-in icon for informational notifications.
+        /// </summary>
+        NotificationColor InformationIconColor { get; set; }
+
+        /// <summary>
         /// Gets or sets the default color for progress indicators.
         /// </summary>
         NotificationColor DefaultProgressColor { get; set; }

--- a/src/Notification.Core/Models/NotificationRequest.cs
+++ b/src/Notification.Core/Models/NotificationRequest.cs
@@ -129,6 +129,12 @@ namespace Notification.Core
         public object Icon { get; set; }
 
         /// <summary>
+        /// Gets or sets the color applied to the built-in type icon. When null, the per-type color
+        /// from configuration is used. Has no effect when a custom <see cref="Icon"/> is supplied.
+        /// </summary>
+        public NotificationColor? IconColor { get; set; }
+
+        /// <summary>
         /// Gets or sets the platform-specific image object for the notification.
         /// </summary>
         public object PlatformImage { get; set; }

--- a/src/Notification.Core/Notification.Core.csproj
+++ b/src/Notification.Core/Notification.Core.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.1.0</Version>
+    <Version>10.1.0.0</Version>
     <!-- NuGet id differs from the assembly name: "Notification.Core" is too generic and may conflict with reserved prefixes. -->
     <PackageId>Notification.CoreUI</PackageId>
     <SignAssembly>true</SignAssembly>

--- a/src/Notification.Core/Notification.Core.xml
+++ b/src/Notification.Core/Notification.Core.xml
@@ -626,6 +626,36 @@
             Gets or sets the background color for information notifications.
             </summary>
         </member>
+        <member name="P:Notification.Core.NotificationConfiguration.DefaultIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for notifications without a specific type.
+            Defaults to white so the out-of-the-box appearance is unchanged.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.SuccessIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for success notifications.
+            Defaults to white so the out-of-the-box appearance is unchanged.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.WarningIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for warning notifications.
+            Defaults to white so the out-of-the-box appearance is unchanged.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.ErrorIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for error notifications.
+            Defaults to white so the out-of-the-box appearance is unchanged.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationConfiguration.InformationIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for information notifications.
+            Defaults to white so the out-of-the-box appearance is unchanged.
+            </summary>
+        </member>
         <member name="P:Notification.Core.NotificationConfiguration.DefaultProgressColor">
             <summary>
             Gets or sets the default color for progress bar indicators.
@@ -1245,6 +1275,31 @@
             Gets or sets the background color for informational notifications.
             </summary>
         </member>
+        <member name="P:Notification.Core.INotificationConfiguration.DefaultIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for notifications without a specific type.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.SuccessIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for success notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.WarningIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for warning notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.ErrorIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for error notifications.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.INotificationConfiguration.InformationIconColor">
+            <summary>
+            Gets or sets the color of the built-in icon for informational notifications.
+            </summary>
+        </member>
         <member name="P:Notification.Core.INotificationConfiguration.DefaultProgressColor">
             <summary>
             Gets or sets the default color for progress indicators.
@@ -1753,6 +1808,12 @@
         <member name="P:Notification.Core.NotificationRequest.Icon">
             <summary>
             Gets or sets the icon displayed in the notification. The type is platform-dependent.
+            </summary>
+        </member>
+        <member name="P:Notification.Core.NotificationRequest.IconColor">
+            <summary>
+            Gets or sets the color applied to the built-in type icon. When null, the per-type color
+            from configuration is used. Has no effect when a custom <see cref="P:Notification.Core.NotificationRequest.Icon"/> is supplied.
             </summary>
         </member>
         <member name="P:Notification.Core.NotificationRequest.PlatformImage">

--- a/src/Notification.Maui/Notification.Maui.csproj
+++ b/src/Notification.Maui/Notification.Maui.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-android;net10.0-ios;net10.0-maccatalyst;net10.0</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::IsOSPlatform('windows'))">$(TargetFrameworks);net10.0-windows10.0.19041.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.1.0</Version>
+    <Version>10.1.0.0</Version>
     <IsPackable>true</IsPackable>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <UseMaui>true</UseMaui>

--- a/src/Notification.Wpf/Base/Interfaces/Options/ICustomizedOptions.cs
+++ b/src/Notification.Wpf/Base/Interfaces/Options/ICustomizedOptions.cs
@@ -10,6 +10,8 @@ namespace Notification.Wpf.Base.Interfaces.Options
     {
         /// <summary> icon in left bar side </summary>
         public object Icon { get; set; }
+        /// <summary> Color applied to the built-in type icon. When null, the per-type color from configuration is used. Ignored when a custom <see cref="Icon"/> is supplied. </summary>
+        public Brush IconForeground { get; set; }
         /// <summary> Notification background </summary>
         public Brush Background { get; set; }
         /// <summary> Text foreground </summary>

--- a/src/Notification.Wpf/Base/Notification/NotificationContent.cs
+++ b/src/Notification.Wpf/Base/Notification/NotificationContent.cs
@@ -111,6 +111,7 @@ namespace Notification.Wpf
                 Background = options?.Background ?? NotificationConstants.DefaultBackgroundColor,
                 Foreground = options?.Foreground ?? NotificationConstants.DefaultForegroundColor,
                 Icon = options?.Icon,
+                IconForeground = options?.IconForeground,
                 MessageTextSettings = options?.MessageTextSettings,
                 TitleTextSettings = options?.TitleTextSettings,
                 RowsCount = options?.RowsCount is { } count and > 0 ? count : 1,

--- a/src/Notification.Wpf/Base/NotificationManager.cs
+++ b/src/Notification.Wpf/Base/NotificationManager.cs
@@ -518,6 +518,7 @@ namespace Notification.Wpf
                     TitleTextSettings = titleSettings,
                     MessageTextSettings = messageSettings,
                     Icon = request.Icon,
+                    IconForeground = request.IconColor?.ToBrush(),
                     Image = image
                 };
             }

--- a/src/Notification.Wpf/Base/Options/CustomizedOptions.cs
+++ b/src/Notification.Wpf/Base/Options/CustomizedOptions.cs
@@ -13,6 +13,9 @@ namespace Notification.Wpf.Base.Options
         public object Icon { get; set; }
 
         /// <inheritdoc />
+        public Brush IconForeground { get; set; }
+
+        /// <inheritdoc />
         public Brush Background { get; set; }
 
         /// <inheritdoc />
@@ -56,6 +59,7 @@ namespace Notification.Wpf.Base.Options
             Background = options?.Background ?? NotificationConstants.DefaultBackgroundColor,
             Foreground = options?.Foreground ?? NotificationConstants.DefaultForegroundColor,
             Icon = options?.Icon,
+            IconForeground = options?.IconForeground,
             MessageTextSettings = options?.MessageTextSettings,
             TitleTextSettings = options?.TitleTextSettings,
             RowsCount = options?.RowsCount is { } count and > 0 ? count : 1,

--- a/src/Notification.Wpf/Constants/NotificationConstants.cs
+++ b/src/Notification.Wpf/Constants/NotificationConstants.cs
@@ -34,6 +34,12 @@ namespace Notification.Wpf.Constants
             InformationBackgroundColor = config.InformationBackgroundColor.ToBrush();
             DefaultProgressColor = config.DefaultProgressColor.ToBrush();
 
+            DefaultIconColor = config.DefaultIconColor.ToBrush();
+            SuccessIconColor = config.SuccessIconColor.ToBrush();
+            WarningIconColor = config.WarningIconColor.ToBrush();
+            ErrorIconColor = config.ErrorIconColor.ToBrush();
+            InformationIconColor = config.InformationIconColor.ToBrush();
+
             BaseTextSize = config.BaseTextSize;
             TitleSize = config.TitleSize;
             MessageSize = config.MessageSize;
@@ -96,27 +102,18 @@ namespace Notification.Wpf.Constants
         public static Brush DefaultProgressColor { get; set; } = (Brush)new BrushConverter().ConvertFrom("#FF01D328");
         #endregion
 
-        #region Default Icons
+        #region Icon colors
 
-        //public static SolidColorBrush DefaultIconColorBrush = new(Colors.White);
-
-        //public static object SuccessIcon = new Path()
-        //{
-        //    Data = Geometry.Parse("M 15.56055 5.9323048e-7 7.53125 10.197261 2.73242 5.2304706 0 7.8710906 7.82422 15.968751 18.54492 2.3515606 15.56055 5.9323048e-7 Z"),
-        //    Fill = DefaultIconColorBrush
-        //};
-        //public static object ErrorIcon = new SvgAwesome() { Icon = EFontAwesomeIcon.Solid_Bug, Height = 20, Foreground = DefaultIconColorBrush };
-        //public static object WarningIcon = new Path()
-        //{
-        //    Data = Geometry.Parse("M 12.414089 4.6396565e-7 C 12.128679 -9.5360343e-6 11.832699 0.06810046 11.574249 0.19726046 c -0.29252 0.14627 -0.55012 0.39584 -0.70899 0.67383 l -0.002 0.002 L 0.22067905 19.77348 l -0.0117 0.0234 C 0.08326905 20.04831 -9.5367432e-7 20.33976 -9.5367432e-7 20.64844 c 0 0.30629 0.0851000036743 0.62597 0.23633000367432 0.89063 0.13469 0.2357 0.31957 0.44504 0.5332 0.60937 l 0.0137 0.0117 0.0156 0.01 C 1.076789 22.36867 1.440719 22.48654 1.785149 22.48654 l 21.28516 0 c 0.3398 0 0.70907 -0.12364 0.98828 -0.33398 0.2208 -0.16158 0.42089 -0.3689 0.56055 -0.61328 0.15122 -0.26466 0.23633 -0.58434 0.23633 -0.89063 0 -0.30868 -0.0852 -0.60013 -0.21094 -0.85156 l -0.01 -0.0234 -10.66992 -18.90038954 -0.002 -0.002 c -0.15887 -0.27808 -0.41633 -0.52756 -0.70899 -0.67383 -0.25845 -0.12918 -0.55443 -0.19726999603 -0.83984 -0.19725999603 z m 0 2.19531003603435 10.32617 18.2910095 -20.625 0 10.29883 -18.2910095 z m -1.48633 3.84765 0 8.9121095 3 0 0 -8.9121095 -3 0 z m 0 10.3808595 0 3 3 0 0 -3 -3 0 z"),
-        //    Fill = DefaultIconColorBrush
-        //};
-        //public static object InformationIcon = new Path()
-        //{
-        //    Data = Geometry.Parse("M 10.968748 8.9809305e-8 C 4.9320181 8.9809305e-8 -1.9073487e-6 4.9320201 -1.9073487e-6 10.96875 c 0 6.03672 4.9322600073487 10.9668 10.9687499073487 10.9668 6.03648 0 10.96875 -4.93008 10.96875 -10.9668 C 21.937498 4.9320201 17.005458 8.9809305e-8 10.968748 8.9809305e-8 Z m 0 2.000000010190695 c 4.95043 0 8.96875 4.0183 8.96875 8.9687499 0 4.95044 -4.01809 8.9668 -8.96875 8.9668 -4.9506899 0 -8.9687499 -4.01636 -8.9687499 -8.9668 0 -4.9504499 4.0183 -8.9687499 8.9687499 -8.9687499 z m -1.4999999 2.49805 0 3 2.9999999 0 0 -3 -2.9999999 0 z m 0 4.4707 0 8.9101599 2.9999999 0 0 -8.9101599 -2.9999999 0 z"),
-        //    Fill = Brushes.White
-        //};
-        //public static object NotificationIcon = InformationIcon;
+        /// <summary> built-in icon color for notifications without a specific type </summary>
+        public static Brush DefaultIconColor { get; set; } = new SolidColorBrush(Colors.White);
+        /// <summary> built-in icon color for success notifications </summary>
+        public static Brush SuccessIconColor { get; set; } = new SolidColorBrush(Colors.White);
+        /// <summary> built-in icon color for warning notifications </summary>
+        public static Brush WarningIconColor { get; set; } = new SolidColorBrush(Colors.White);
+        /// <summary> built-in icon color for error notifications </summary>
+        public static Brush ErrorIconColor { get; set; } = new SolidColorBrush(Colors.White);
+        /// <summary> built-in icon color for information notifications </summary>
+        public static Brush InformationIconColor { get; set; } = new SolidColorBrush(Colors.White);
 
         #endregion
 

--- a/src/Notification.Wpf/Notification.Wpf.csproj
+++ b/src/Notification.Wpf/Notification.Wpf.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net10.0-windows;net9.0-windows;net8.0-windows;net4.8-windows</TargetFrameworks>
     <UseWPF>true</UseWPF>
     <LangVersion>latest</LangVersion>
-    <Version>10.0.1.0</Version>
+    <Version>10.1.0.0</Version>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>Notifications.Wpf.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>

--- a/src/Notification.Wpf/Notification.Wpf.xml
+++ b/src/Notification.Wpf/Notification.Wpf.xml
@@ -366,6 +366,9 @@
         <member name="P:Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions.Icon">
             <summary> icon in left bar side </summary>
         </member>
+        <member name="P:Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions.IconForeground">
+            <summary> Color applied to the built-in type icon. When null, the per-type color from configuration is used. Ignored when a custom <see cref="P:Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions.Icon"/> is supplied. </summary>
+        </member>
         <member name="P:Notification.Wpf.Base.Interfaces.Options.ICustomizedOptions.Background">
             <summary> Notification background </summary>
         </member>
@@ -388,6 +391,9 @@
             <inheritdoc />
         </member>
         <member name="P:Notification.Wpf.Base.Options.CustomizedOptions.Icon">
+            <inheritdoc />
+        </member>
+        <member name="P:Notification.Wpf.Base.Options.CustomizedOptions.IconForeground">
             <inheritdoc />
         </member>
         <member name="P:Notification.Wpf.Base.Options.CustomizedOptions.Background">
@@ -877,6 +883,21 @@
         </member>
         <member name="P:Notification.Wpf.Constants.NotificationConstants.DefaultProgressColor">
             <summary> default progress line foreground </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.DefaultIconColor">
+            <summary> built-in icon color for notifications without a specific type </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.SuccessIconColor">
+            <summary> built-in icon color for success notifications </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.WarningIconColor">
+            <summary> built-in icon color for warning notifications </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.ErrorIconColor">
+            <summary> built-in icon color for error notifications </summary>
+        </member>
+        <member name="P:Notification.Wpf.Constants.NotificationConstants.InformationIconColor">
+            <summary> built-in icon color for information notifications </summary>
         </member>
         <member name="P:Notification.Wpf.Constants.NotificationConstants.DefaultRowCounts">
             <summary> visible rows count in message by default</summary>
@@ -2125,6 +2146,9 @@
             <summary>progress line color</summary>
         </member>
         <member name="P:Notifications.Wpf.ViewModels.NotificationProgressViewModel.Icon">
+            <inheritdoc />
+        </member>
+        <member name="P:Notifications.Wpf.ViewModels.NotificationProgressViewModel.IconForeground">
             <inheritdoc />
         </member>
         <member name="P:Notifications.Wpf.ViewModels.NotificationProgressViewModel.Background">

--- a/src/Notification.Wpf/Themes/Generic.xaml
+++ b/src/Notification.Wpf/Themes/Generic.xaml
@@ -69,11 +69,6 @@
           Data="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
           Fill="{StaticResource WhiteBrush}" x:Shared="False" />-->
 
-    <Viewbox x:Key="ErrorIcon" Height="20" x:Shared="False" >
-        <Path 
-                  Data="M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z"
-                  Fill="{StaticResource WhiteBrush}" />
-    </Viewbox>
     <Viewbox x:Key="CloseIcon" Height="12" x:Shared="False" >
         <Path 
               Data="M464 32H48C21.5 32 0 53.5 0 80v352c0 26.5 21.5 48 48 48h416c26.5 0 48-21.5 48-48V80c0-26.5-21.5-48-48-48zm0 394c0 3.3-2.7 6-6 6H54c-3.3 0-6-2.7-6-6V86c0-3.3 2.7-6 6-6h404c3.3 0 6 2.7 6 6v340zM356.5 194.6L295.1 256l61.4 61.4c4.6 4.6 4.6 12.1 0 16.8l-22.3 22.3c-4.6 4.6-12.1 4.6-16.8 0L256 295.1l-61.4 61.4c-4.6 4.6-12.1 4.6-16.8 0l-22.3-22.3c-4.6-4.6-4.6-12.1 0-16.8l61.4-61.4-61.4-61.4c-4.6-4.6-4.6-12.1 0-16.8l22.3-22.3c4.6-4.6 12.1-4.6 16.8 0l61.4 61.4 61.4-61.4c4.6-4.6 12.1-4.6 16.8 0l22.3 22.3c4.7 4.6 4.7 12.1 0 16.8z"
@@ -110,15 +105,12 @@
     </Viewbox>
 
 
-    <Path x:Key="SuccessIcon"
-          Data="M 15.56055 5.9323048e-7 7.53125 10.197261 2.73242 5.2304706 0 7.8710906 7.82422 15.968751 18.54492 2.3515606 15.56055 5.9323048e-7 Z"
-          Fill="{StaticResource WhiteBrush}" x:Shared="False" />
-    <Path x:Key="InfoIcon"
-          Data="M 10.968748 8.9809305e-8 C 4.9320181 8.9809305e-8 -1.9073487e-6 4.9320201 -1.9073487e-6 10.96875 c 0 6.03672 4.9322600073487 10.9668 10.9687499073487 10.9668 6.03648 0 10.96875 -4.93008 10.96875 -10.9668 C 21.937498 4.9320201 17.005458 8.9809305e-8 10.968748 8.9809305e-8 Z m 0 2.000000010190695 c 4.95043 0 8.96875 4.0183 8.96875 8.9687499 0 4.95044 -4.01809 8.9668 -8.96875 8.9668 -4.9506899 0 -8.9687499 -4.01636 -8.9687499 -8.9668 0 -4.9504499 4.0183 -8.9687499 8.9687499 -8.9687499 z m -1.4999999 2.49805 0 3 2.9999999 0 0 -3 -2.9999999 0 z m 0 4.4707 0 8.9101599 2.9999999 0 0 -8.9101599 -2.9999999 0 z"
-          Fill="{StaticResource WhiteBrush}" x:Shared="False" />
-    <Path x:Key="WarningIcon"
-          Data="M 12.414089 4.6396565e-7 C 12.128679 -9.5360343e-6 11.832699 0.06810046 11.574249 0.19726046 c -0.29252 0.14627 -0.55012 0.39584 -0.70899 0.67383 l -0.002 0.002 L 0.22067905 19.77348 l -0.0117 0.0234 C 0.08326905 20.04831 -9.5367432e-7 20.33976 -9.5367432e-7 20.64844 c 0 0.30629 0.0851000036743 0.62597 0.23633000367432 0.89063 0.13469 0.2357 0.31957 0.44504 0.5332 0.60937 l 0.0137 0.0117 0.0156 0.01 C 1.076789 22.36867 1.440719 22.48654 1.785149 22.48654 l 21.28516 0 c 0.3398 0 0.70907 -0.12364 0.98828 -0.33398 0.2208 -0.16158 0.42089 -0.3689 0.56055 -0.61328 0.15122 -0.26466 0.23633 -0.58434 0.23633 -0.89063 0 -0.30868 -0.0852 -0.60013 -0.21094 -0.85156 l -0.01 -0.0234 -10.66992 -18.90038954 -0.002 -0.002 c -0.15887 -0.27808 -0.41633 -0.52756 -0.70899 -0.67383 -0.25845 -0.12918 -0.55443 -0.19726999603 -0.83984 -0.19725999603 z m 0 2.19531003603435 10.32617 18.2910095 -20.625 0 10.29883 -18.2910095 z m -1.48633 3.84765 0 8.9121095 3 0 0 -8.9121095 -3 0 z m 0 10.3808595 0 3 3 0 0 -3 -3 0 z"
-          Fill="{StaticResource WhiteBrush}" x:Shared="False" />
+    <!-- Geometries for the built-in type icons. Kept Fill-free so the icon color can be set
+         per type / per notification at render time (issue #82). -->
+    <StreamGeometry x:Key="SuccessIconGeometry" p:Freeze="True">M 15.56055 5.9323048e-7 7.53125 10.197261 2.73242 5.2304706 0 7.8710906 7.82422 15.968751 18.54492 2.3515606 15.56055 5.9323048e-7 Z</StreamGeometry>
+    <StreamGeometry x:Key="InfoIconGeometry" p:Freeze="True">M 10.968748 8.9809305e-8 C 4.9320181 8.9809305e-8 -1.9073487e-6 4.9320201 -1.9073487e-6 10.96875 c 0 6.03672 4.9322600073487 10.9668 10.9687499073487 10.9668 6.03648 0 10.96875 -4.93008 10.96875 -10.9668 C 21.937498 4.9320201 17.005458 8.9809305e-8 10.968748 8.9809305e-8 Z m 0 2.000000010190695 c 4.95043 0 8.96875 4.0183 8.96875 8.9687499 0 4.95044 -4.01809 8.9668 -8.96875 8.9668 -4.9506899 0 -8.9687499 -4.01636 -8.9687499 -8.9668 0 -4.9504499 4.0183 -8.9687499 8.9687499 -8.9687499 z m -1.4999999 2.49805 0 3 2.9999999 0 0 -3 -2.9999999 0 z m 0 4.4707 0 8.9101599 2.9999999 0 0 -8.9101599 -2.9999999 0 z</StreamGeometry>
+    <StreamGeometry x:Key="WarningIconGeometry" p:Freeze="True">M 12.414089 4.6396565e-7 C 12.128679 -9.5360343e-6 11.832699 0.06810046 11.574249 0.19726046 c -0.29252 0.14627 -0.55012 0.39584 -0.70899 0.67383 l -0.002 0.002 L 0.22067905 19.77348 l -0.0117 0.0234 C 0.08326905 20.04831 -9.5367432e-7 20.33976 -9.5367432e-7 20.64844 c 0 0.30629 0.0851000036743 0.62597 0.23633000367432 0.89063 0.13469 0.2357 0.31957 0.44504 0.5332 0.60937 l 0.0137 0.0117 0.0156 0.01 C 1.076789 22.36867 1.440719 22.48654 1.785149 22.48654 l 21.28516 0 c 0.3398 0 0.70907 -0.12364 0.98828 -0.33398 0.2208 -0.16158 0.42089 -0.3689 0.56055 -0.61328 0.15122 -0.26466 0.23633 -0.58434 0.23633 -0.89063 0 -0.30868 -0.0852 -0.60013 -0.21094 -0.85156 l -0.01 -0.0234 -10.66992 -18.90038954 -0.002 -0.002 c -0.15887 -0.27808 -0.41633 -0.52756 -0.70899 -0.67383 -0.25845 -0.12918 -0.55443 -0.19726999603 -0.83984 -0.19725999603 z m 0 2.19531003603435 10.32617 18.2910095 -20.625 0 10.29883 -18.2910095 z m -1.48633 3.84765 0 8.9121095 3 0 0 -8.9121095 -3 0 z m 0 10.3808595 0 3 3 0 0 -3 -3 0 z</StreamGeometry>
+    <StreamGeometry x:Key="ErrorIconGeometry" p:Freeze="True">M511.988 288.9c-.478 17.43-15.217 31.1-32.653 31.1H424v16c0 21.864-4.882 42.584-13.6 61.145l60.228 60.228c12.496 12.497 12.496 32.758 0 45.255-12.498 12.497-32.759 12.496-45.256 0l-54.736-54.736C345.886 467.965 314.351 480 280 480V236c0-6.627-5.373-12-12-12h-24c-6.627 0-12 5.373-12 12v244c-34.351 0-65.886-12.035-90.636-32.108l-54.736 54.736c-12.498 12.497-32.759 12.496-45.256 0-12.496-12.497-12.496-32.758 0-45.255l60.228-60.228C92.882 378.584 88 357.864 88 336v-16H32.666C15.23 320 .491 306.33.013 288.9-.484 270.816 14.028 256 32 256h56v-58.745l-46.628-46.628c-12.496-12.497-12.496-32.758 0-45.255 12.498-12.497 32.758-12.497 45.256 0L141.255 160h229.489l54.627-54.627c12.498-12.497 32.758-12.497 45.256 0 12.496 12.497 12.496 32.758 0 45.255L424 197.255V256h56c17.972 0 32.484 14.816 31.988 32.9zM257 0c-61.856 0-112 50.144-112 112h224C369 50.144 318.856 0 257 0z</StreamGeometry>
 
     <ControlTemplate x:Key="OverButtonControlTemplate" TargetType="{x:Type ButtonBase}">
         <Border x:Name="TemplateBorder" Background="{StaticResource TransparentBrush}"
@@ -241,13 +233,19 @@
                         <ContentControl Grid.Row="1" Grid.Column="0" Margin="0,0,12,0" Width="25" VerticalAlignment="Stretch">
                             <DockPanel x:Name="LeftPanel">
 
-                                <ContentControl DockPanel.Dock="Top" x:Name="Icon" HorizontalAlignment="Center" VerticalAlignment="Top">
-                                    <ContentControl.Resources>
-                                        <DataTemplate DataType="{x:Type ImageSource}">
-                                            <Image Source="{Binding }"/>
-                                        </DataTemplate>
-                                    </ContentControl.Resources>
-                                </ContentControl>
+                                <!-- Icon slot: built-in tintable type icon, replaced by a custom Icon object when supplied (issue #82). -->
+                                <Grid DockPanel.Dock="Top" HorizontalAlignment="Center" VerticalAlignment="Top">
+                                    <Viewbox x:Name="TypeIcon">
+                                        <Path x:Name="TypeIconPath"/>
+                                    </Viewbox>
+                                    <ContentControl x:Name="CustomIcon">
+                                        <ContentControl.Resources>
+                                            <DataTemplate DataType="{x:Type ImageSource}">
+                                                <Image Source="{Binding }"/>
+                                            </DataTemplate>
+                                        </ContentControl.Resources>
+                                    </ContentControl>
+                                </Grid>
 
                                 <Button x:Name="Attach" DockPanel.Dock="Bottom"
                                         HorizontalAlignment="Center" VerticalAlignment="Bottom"
@@ -334,27 +332,43 @@
                         <Setter TargetName="MessageBox" Property="TextTrimming" Value="None"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Type}" Value="Notification">
-                        <Setter TargetName="Icon" Property="Content" Value="{StaticResource InfoIcon}"/>
+                        <Setter TargetName="TypeIcon" Property="Height" Value="20"/>
+                        <Setter TargetName="TypeIconPath" Property="Data" Value="{StaticResource InfoIconGeometry}"/>
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding Source={x:Static constants:NotificationConstants.DefaultIconColor}}"/>
                         <Setter TargetName="Border" Property="Background" Value="{Binding Source={x:Static constants:NotificationConstants.DefaultBackgroundColor}}"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Type}" Value="Information">
-                        <Setter TargetName="Icon" Property="Content" Value="{StaticResource InfoIcon}"/>
+                        <Setter TargetName="TypeIcon" Property="Height" Value="20"/>
+                        <Setter TargetName="TypeIconPath" Property="Data" Value="{StaticResource InfoIconGeometry}"/>
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding Source={x:Static constants:NotificationConstants.InformationIconColor}}"/>
                         <Setter TargetName="Border" Property="Background" Value="{Binding Source={x:Static constants:NotificationConstants.InformationBackgroundColor}}"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Type}" Value="Success">
-                        <Setter TargetName="Icon" Property="Content" Value="{StaticResource SuccessIcon}"/>
+                        <Setter TargetName="TypeIcon" Property="Height" Value="20"/>
+                        <Setter TargetName="TypeIconPath" Property="Data" Value="{StaticResource SuccessIconGeometry}"/>
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding Source={x:Static constants:NotificationConstants.SuccessIconColor}}"/>
                         <Setter TargetName="Border" Property="Background" Value="{Binding Source={x:Static constants:NotificationConstants.SuccessBackgroundColor}}"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Type}" Value="Warning">
-                        <Setter TargetName="Icon" Property="Content" Value="{StaticResource WarningIcon}"/>
+                        <Setter TargetName="TypeIcon" Property="Height" Value="20"/>
+                        <Setter TargetName="TypeIconPath" Property="Data" Value="{StaticResource WarningIconGeometry}"/>
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding Source={x:Static constants:NotificationConstants.WarningIconColor}}"/>
                         <Setter TargetName="Border" Property="Background" Value="{Binding Source={x:Static constants:NotificationConstants.WarningBackgroundColor}}"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Type}" Value="Error">
-                        <Setter TargetName="Icon" Property="Content" Value="{StaticResource ErrorIcon}"/>
+                        <Setter TargetName="TypeIcon" Property="Height" Value="20"/>
+                        <Setter TargetName="TypeIconPath" Property="Data" Value="{StaticResource ErrorIconGeometry}"/>
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding Source={x:Static constants:NotificationConstants.ErrorIconColor}}"/>
                         <Setter TargetName="Border" Property="Background" Value="{Binding Source={x:Static constants:NotificationConstants.ErrorBackgroundColor}}"/>
                     </DataTrigger>
+                    <!-- Per-notification icon color override (issue #82). Placed after the Type triggers so it wins. -->
+                    <DataTrigger Binding="{Binding IconForeground, Converter={wpf:IsNull}}" Value="false">
+                        <Setter TargetName="TypeIconPath" Property="Fill" Value="{Binding IconForeground}"/>
+                    </DataTrigger>
+                    <!-- A custom Icon object replaces the built-in type icon entirely. -->
                     <DataTrigger Binding="{Binding Icon, Converter={wpf:IsNull}}" Value="false">
-                        <Setter TargetName="Icon" Property="Content" Value="{Binding Icon}"/>
+                        <Setter TargetName="CustomIcon" Property="Content" Value="{Binding Icon}"/>
+                        <Setter TargetName="TypeIcon" Property="Visibility" Value="Collapsed"/>
                     </DataTrigger>
                     <DataTrigger Binding="{Binding Background, Converter={wpf:IsNull}}" Value="false">
                         <Setter TargetName="Border" Property="Background" Value="{Binding Background}"/>

--- a/src/Notification.Wpf/ViewModels/NotificationProgressViewModel.cs
+++ b/src/Notification.Wpf/ViewModels/NotificationProgressViewModel.cs
@@ -109,6 +109,10 @@ namespace Notifications.Wpf.ViewModels
         /// <inheritdoc />
         public object Icon { get => _Icon; set => Set(ref _Icon, value); }
 
+        private Brush _IconForeground;
+        /// <inheritdoc />
+        public Brush IconForeground { get => _IconForeground; set => Set(ref _IconForeground, value); }
+
 
         #endregion
 


### PR DESCRIPTION
## Summary
- Implements #82 — the built-in Success / Warning / Error / Information icons can now be tinted by status, instead of only the notification background.
- **Core:** new icon color properties on `INotificationConfiguration` / `NotificationConfiguration` (`DefaultIconColor`, `SuccessIconColor`, `WarningIconColor`, `ErrorIconColor`, `InformationIconColor`); new `NotificationRequest.IconColor`.
- **WPF:** new `IconForeground` on `NotificationContent` / `ICustomizedOptions`; built-in icons reworked in `Generic.xaml` into tintable geometries.
- **Sample:** new "Use icon color" and "Override type background" toggles in the WPF sample.
- All icon colors default to white — the out-of-the-box appearance is unchanged. All packages bumped to `10.1.0.0`.

## Compatibility
- Purely additive: only `NotificationConfiguration` implements the changed interface; all consumers (Maui / Avalonia / Console) only consume it. `NotificationRequest.IconColor` is an optional nullable property.
- Non-WPF platforms have no functional change.

## Test plan
- [x] Builds: Core, WPF, Console, Avalonia, Maui, WPF sample — 0 errors / 0 warnings
- [x] Unit tests: 95 Core + 23 WPF — all pass
- [x] Manual: default Success / Information notifications unchanged (white icon on type background)
- [x] Manual: per-notification `IconForeground` tints the built-in icon on a neutral background (reproduces #82)
- [x] Manual: a custom `Icon` object still replaces the built-in icon