### PR TITLE
Fix Avalonia notification in 2 steps only without strong coupling

### DIFF
--- a/Samples/Notification.Avalonia.Sample/MainWindow.axaml
+++ b/Samples/Notification.Avalonia.Sample/MainWindow.axaml
@@ -27,7 +27,7 @@
                 </StackPanel>
                 <StackPanel Margin="0,0,16,4" VerticalAlignment="Bottom">
                     <CheckBox Name="ChkOverlayWindow" Content="Overlay window (outside app)"
-                              IsChecked="False" Margin="0,0,0,6"
+                              IsChecked="True" Margin="0,0,0,6"
                               Click="OnOverlayModeChanged" />
                 </StackPanel>
             </WrapPanel>

--- a/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
+++ b/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
@@ -1,3 +1,6 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -6,16 +9,20 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Notification.Core;
-using System;
-using System.IO;
-using System.Threading.Tasks;
 
 namespace Notification.Avalonia.Sample
 {
     public partial class MainWindow : Window
     {
-        private static IServiceProvider _serviceProvider;
-        
+        private readonly IServiceProvider _serviceProvider;
+
+        private INotificationService Notification 
+            => _serviceProvider.GetRequiredService<INotificationService>();
+        private INotificationEventService Event
+            => _serviceProvider.GetRequiredService<INotificationEventService>();
+        private AvaloniaNotificationManager Manager
+            => _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+
         public MainWindow()
         {
             InitializeComponent();
@@ -28,9 +35,7 @@ namespace Notification.Avalonia.Sample
 
             _serviceProvider = services.BuildServiceProvider();
 
-            var events = _serviceProvider.GetRequiredService<INotificationEventService>();
-
-            events.NotificationLifecycleChanged += (sender, e) =>
+            Event.NotificationLifecycleChanged += (sender, e) =>
             {
                 Dispatcher.UIThread.Post(() =>
                 {
@@ -45,36 +50,32 @@ namespace Notification.Avalonia.Sample
 
         private void OnShowSuccess(object sender, RoutedEventArgs e)
         {
-            _serviceProvider.GetRequiredService<INotificationService>()
-                .Show(NotificationBuilder.Create("Success", "Operation completed").AsSuccess().Build());
+            Notification.Show(NotificationBuilder.Create("Success", "Operation completed").AsSuccess().Build());
         }
 
         private void OnShowWarning(object sender, RoutedEventArgs e)
         {
-            _serviceProvider.GetRequiredService<INotificationService>()
-                .Show(NotificationBuilder.Create("Warning", "Disk space low").AsWarning().Build());
+            Notification.Show(NotificationBuilder.Create("Warning", "Disk space low").AsWarning().Build());
         }
 
         private void OnShowError(object sender, RoutedEventArgs e)
         {
-            _serviceProvider.GetRequiredService<INotificationService>()
-                .Show(NotificationBuilder.Create("Error", "Connection failed").AsError().NeverExpires().Build());
+            Notification.Show(NotificationBuilder.Create("Error", "Connection failed").AsError().NeverExpires().Build());
         }
 
         private void OnShowInfo(object sender, RoutedEventArgs e)
         {
-            _serviceProvider.GetRequiredService<INotificationService>()
-                .Show(NotificationBuilder.Create("Info", "Update available").AsInformation().Build());
+            Notification.Show(NotificationBuilder.Create("Info", "Update available").AsInformation().Build());
         }
 
         private void OnDismissAll(object sender, RoutedEventArgs e)
         {
-            _serviceProvider.GetRequiredService<INotificationService>().DismissAll();
+            Notification.DismissAll();
         }
 
         private void OnOverlayModeChanged(object sender, RoutedEventArgs e)
         {
-            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            var manager = Manager;
             CheckBox chk = sender as CheckBox;
             if (chk == null || manager == null)
                 return;
@@ -83,11 +84,11 @@ namespace Notification.Avalonia.Sample
 
         private void OnPositionChanged(object sender, SelectionChangedEventArgs e)
         {
-            if (_serviceProvider is null)
+            if (_serviceProvider is null) // prevent the event from triggering during initialization
             {
                 return;
             }
-            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            var manager = Manager;
             
             ComboBox cmbPosition = sender as ComboBox;
             if (cmbPosition == null || manager == null)
@@ -143,7 +144,7 @@ namespace Notification.Avalonia.Sample
                 })
                 .Build();
 
-            _serviceProvider.GetRequiredService<INotificationService>().Show(request);
+            Notification.Show(request);
         }
 
         private void OnShowCustomContent(object sender, RoutedEventArgs e)
@@ -231,8 +232,7 @@ namespace Notification.Avalonia.Sample
                 TextWrapping = TextWrapping.Wrap
             });
 
-            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
-            manager.ShowCustomContent(content, TimeSpan.FromSeconds(10),
+            Manager.ShowCustomContent(content, TimeSpan.FromSeconds(10),
                 NotificationColor.FromHex("#37474F"));
         }
 
@@ -290,7 +290,7 @@ namespace Notification.Avalonia.Sample
             if (chkCustomFg?.IsChecked == true && !string.IsNullOrEmpty(txtFgColor?.Text))
                 builder.WithForeground(txtFgColor.Text);
 
-            _serviceProvider.GetRequiredService<INotificationService>().Show(builder.Build());
+            Notification.Show(builder.Build());
         }
 
         private static NotificationType GetSelectedType(int index)
@@ -315,8 +315,7 @@ namespace Notification.Avalonia.Sample
             if (btnProgress != null)
                 btnProgress.IsEnabled = false;
 
-            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
-            using INotifierProgress progress = manager.ShowProgressBar(
+            using INotifierProgress progress = Manager.ShowProgressBar(
                 "Downloading update...",
                 showCancelButton: true,
                 waitingMessage: "Calculating time");
@@ -350,8 +349,7 @@ namespace Notification.Avalonia.Sample
             string title = txtProgressTitle?.Text ?? "Processing...";
             bool showCancel = chkProgressCancel?.IsChecked ?? true;
 
-            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
-            using INotifierProgress progress = manager.ShowProgressBar(
+            using INotifierProgress progress = Manager.ShowProgressBar(
                 title,
                 showCancelButton: showCancel,
                 waitingMessage: "Calculating time");

--- a/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
+++ b/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
@@ -9,15 +6,16 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
 using Notification.Core;
+using System;
+using System.IO;
+using System.Threading.Tasks;
 
 namespace Notification.Avalonia.Sample
 {
     public partial class MainWindow : Window
     {
-        private readonly INotificationService _service;
-        private readonly INotificationEventService _events;
-        private readonly AvaloniaNotificationManager _manager;
-
+        private static IServiceProvider _serviceProvider;
+        
         public MainWindow()
         {
             InitializeComponent();
@@ -28,15 +26,11 @@ namespace Notification.Avalonia.Sample
                 config.DefaultExpirationTime = TimeSpan.FromSeconds(5);
             });
 
-            ServiceProvider provider = services.BuildServiceProvider();
+            _serviceProvider = services.BuildServiceProvider();
 
-            _manager = provider.GetRequiredService<AvaloniaNotificationManager>();
-            _manager.SetHost(this);
+            var events = _serviceProvider.GetRequiredService<INotificationEventService>();
 
-            _service = provider.GetRequiredService<INotificationService>();
-            _events = provider.GetRequiredService<INotificationEventService>();
-
-            _events.NotificationLifecycleChanged += (sender, e) =>
+            events.NotificationLifecycleChanged += (sender, e) =>
             {
                 Dispatcher.UIThread.Post(() =>
                 {
@@ -51,42 +45,52 @@ namespace Notification.Avalonia.Sample
 
         private void OnShowSuccess(object sender, RoutedEventArgs e)
         {
-            _service.Show(NotificationBuilder.Create("Success", "Operation completed").AsSuccess().Build());
+            _serviceProvider.GetRequiredService<INotificationService>()
+                .Show(NotificationBuilder.Create("Success", "Operation completed").AsSuccess().Build());
         }
 
         private void OnShowWarning(object sender, RoutedEventArgs e)
         {
-            _service.Show(NotificationBuilder.Create("Warning", "Disk space low").AsWarning().Build());
+            _serviceProvider.GetRequiredService<INotificationService>()
+                .Show(NotificationBuilder.Create("Warning", "Disk space low").AsWarning().Build());
         }
 
         private void OnShowError(object sender, RoutedEventArgs e)
         {
-            _service.Show(NotificationBuilder.Create("Error", "Connection failed").AsError().NeverExpires().Build());
+            _serviceProvider.GetRequiredService<INotificationService>()
+                .Show(NotificationBuilder.Create("Error", "Connection failed").AsError().NeverExpires().Build());
         }
 
         private void OnShowInfo(object sender, RoutedEventArgs e)
         {
-            _service.Show(NotificationBuilder.Create("Info", "Update available").AsInformation().Build());
+            _serviceProvider.GetRequiredService<INotificationService>()
+                .Show(NotificationBuilder.Create("Info", "Update available").AsInformation().Build());
         }
 
         private void OnDismissAll(object sender, RoutedEventArgs e)
         {
-            _service.DismissAll();
+            _serviceProvider.GetRequiredService<INotificationService>().DismissAll();
         }
 
         private void OnOverlayModeChanged(object sender, RoutedEventArgs e)
         {
+            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
             CheckBox chk = sender as CheckBox;
-            if (chk == null || _manager == null)
+            if (chk == null || manager == null)
                 return;
-
-            _manager.UseOverlayWindow = chk.IsChecked == true;
+            manager.UseOverlayWindow = chk.IsChecked == true;
         }
 
         private void OnPositionChanged(object sender, SelectionChangedEventArgs e)
         {
+            if (_serviceProvider is null)
+            {
+                return;
+            }
+            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            
             ComboBox cmbPosition = sender as ComboBox;
-            if (cmbPosition == null || _manager == null)
+            if (cmbPosition == null || manager == null)
                 return;
 
             NotificationPosition position = cmbPosition.SelectedIndex switch
@@ -103,7 +107,7 @@ namespace Notification.Avalonia.Sample
                 _ => NotificationPosition.BottomRight
             };
 
-            _manager.Position = position;
+            manager.Position = position;
         }
 
         private void OnShowImageTop(object sender, RoutedEventArgs e)
@@ -139,7 +143,7 @@ namespace Notification.Avalonia.Sample
                 })
                 .Build();
 
-            _service.Show(request);
+            _serviceProvider.GetRequiredService<INotificationService>().Show(request);
         }
 
         private void OnShowCustomContent(object sender, RoutedEventArgs e)
@@ -227,7 +231,8 @@ namespace Notification.Avalonia.Sample
                 TextWrapping = TextWrapping.Wrap
             });
 
-            _manager.ShowCustomContent(content, TimeSpan.FromSeconds(10),
+            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            manager.ShowCustomContent(content, TimeSpan.FromSeconds(10),
                 NotificationColor.FromHex("#37474F"));
         }
 
@@ -285,7 +290,7 @@ namespace Notification.Avalonia.Sample
             if (chkCustomFg?.IsChecked == true && !string.IsNullOrEmpty(txtFgColor?.Text))
                 builder.WithForeground(txtFgColor.Text);
 
-            _service.Show(builder.Build());
+            _serviceProvider.GetRequiredService<INotificationService>().Show(builder.Build());
         }
 
         private static NotificationType GetSelectedType(int index)
@@ -310,7 +315,8 @@ namespace Notification.Avalonia.Sample
             if (btnProgress != null)
                 btnProgress.IsEnabled = false;
 
-            using INotifierProgress progress = _manager.ShowProgressBar(
+            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            using INotifierProgress progress = manager.ShowProgressBar(
                 "Downloading update...",
                 showCancelButton: true,
                 waitingMessage: "Calculating time");
@@ -344,7 +350,8 @@ namespace Notification.Avalonia.Sample
             string title = txtProgressTitle?.Text ?? "Processing...";
             bool showCancel = chkProgressCancel?.IsChecked ?? true;
 
-            using INotifierProgress progress = _manager.ShowProgressBar(
+            var manager = _serviceProvider.GetRequiredService<AvaloniaNotificationManager>();
+            using INotifierProgress progress = manager.ShowProgressBar(
                 title,
                 showCancelButton: showCancel,
                 waitingMessage: "Calculating time");

--- a/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
+++ b/Samples/Notification.Avalonia.Sample/MainWindow.axaml.cs
@@ -6,8 +6,8 @@ using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Layout;
 using Avalonia.Media;
-using Avalonia.Threading;
 using Microsoft.Extensions.DependencyInjection;
+using Notification.Avalonia.Extensions;
 using Notification.Core;
 
 namespace Notification.Avalonia.Sample
@@ -37,12 +37,12 @@ namespace Notification.Avalonia.Sample
 
             Event.NotificationLifecycleChanged += (sender, e) =>
             {
-                Dispatcher.UIThread.Post(() =>
+                new Action(() =>
                 {
                     TextBlock log = this.FindControl<TextBlock>("TxtLog");
                     if (log != null)
                         log.Text = $"Event: {e.Stage} - {e.Title ?? "N/A"}";
-                });
+                }).InvokeOnUiThread();
             };
         }
 
@@ -271,7 +271,7 @@ namespace Notification.Avalonia.Sample
                 string leftText = txtLeftButton.Text;
                 builder.WithLeftButton(leftText, () =>
                 {
-                    Dispatcher.UIThread.Post(() => SetLog($"Left button '{leftText}' clicked"));
+                    new Action(() => SetLog($"Left button '{leftText}' clicked")).InvokeOnUiThread();
                 });
             }
 
@@ -280,7 +280,7 @@ namespace Notification.Avalonia.Sample
                 string rightText = txtRightButton.Text;
                 builder.WithRightButton(rightText, () =>
                 {
-                    Dispatcher.UIThread.Post(() => SetLog($"Right button '{rightText}' clicked"));
+                    new Action(() => SetLog($"Right button '{rightText}' clicked")).InvokeOnUiThread();
                 });
             }
 
@@ -338,7 +338,7 @@ namespace Notification.Avalonia.Sample
             }
 
             if (btnProgress != null)
-                Dispatcher.UIThread.Post(() => btnProgress.IsEnabled = true);
+                new Action(() => btnProgress.IsEnabled = true).InvokeOnUiThread();
         }
 
         private async void OnShowCustomProgress(object sender, RoutedEventArgs e)
@@ -376,12 +376,12 @@ namespace Notification.Avalonia.Sample
 
         private void SetLog(string text)
         {
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 TextBlock log = this.FindControl<TextBlock>("TxtLog");
                 if (log != null)
                     log.Text = text;
-            });
+            }).InvokeOnUiThread();
         }
     }
 }

--- a/src/Notification.Avalonia/AvaloniaNotificationManager.cs
+++ b/src/Notification.Avalonia/AvaloniaNotificationManager.cs
@@ -27,6 +27,7 @@ namespace Notification.Avalonia
         private Window _parentWindow;
         private NotificationOverlayWindow _overlayWindow;
         private bool _useOverlayWindow;
+        private bool _initialized;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AvaloniaNotificationManager"/> class.
@@ -45,14 +46,6 @@ namespace Notification.Avalonia
         {
             _config = config;
             _events = events;
-
-            var appLifetime = (IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!;
-            var win = appLifetime?.MainWindow;
-            if (win is not null)
-            {
-                SetHost(win);
-            }
-            UseOverlayWindow = true;
         }
 
         /// <summary>
@@ -116,6 +109,25 @@ namespace Notification.Avalonia
         }
 
         /// <summary>
+        /// Gets the top Level Avalonia control, platform agnostic (desktop or mobile/browser).
+        /// </summary>
+        private static TopLevel TopLevel
+        {
+            get
+            {
+                var curentApp = Application.Current;
+                if (curentApp is null || curentApp.ApplicationLifetime is null)
+                {
+                    return null;
+                }
+                var lifetime = curentApp.ApplicationLifetime;
+                return lifetime is IClassicDesktopStyleApplicationLifetime desktop ? desktop.MainWindow
+                    : lifetime is ISingleViewApplicationLifetime singleView ? TopLevel.GetTopLevel(singleView.MainView)
+                    : null;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the notification position. Can be changed at runtime.
         /// </summary>
         public NotificationPosition Position
@@ -148,6 +160,8 @@ namespace Notification.Avalonia
         public Guid ShowCustomContent(Control content, TimeSpan? expirationTime = null,
             NotificationColor? backgroundColor = null)
         {
+            Initialize();
+
             AvaloniaNotificationHost host = ActiveHost;
             if (host == null)
             {
@@ -174,6 +188,8 @@ namespace Notification.Avalonia
         /// </summary>
         public Guid Show(NotificationRequest request)
         {
+            Initialize();
+
             Guid id = request.Id;
 
             AvaloniaNotificationHost host = ActiveHost;
@@ -212,6 +228,7 @@ namespace Notification.Avalonia
             bool showCancelButton = false,
             string waitingMessage = null)
         {
+            Initialize();
             AvaloniaNotificationHost host = ActiveHost;
             if (host == null)
             {
@@ -276,7 +293,7 @@ namespace Notification.Avalonia
             if (_overlayWindow != null && _overlayWindow.IsVisible)
                 return;
 
-            void InitOverlay()
+            DelegateActionToUiThread(new(() =>
             {
                 if (_overlayWindow != null)
                     return;
@@ -299,17 +316,7 @@ namespace Notification.Avalonia
                 }
 
                 _overlayWindow.Show();
-            }
-
-            // this pattern can be used to refactor for action/func and async Tasks
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                InitOverlay();
-            }
-            else
-            {
-                Dispatcher.UIThread.Post(InitOverlay);
-            }
+            }));
         }
 
         private void RepositionOverlayWindow(NotificationPosition position)
@@ -317,22 +324,49 @@ namespace Notification.Avalonia
             if (_overlayWindow == null || _parentWindow == null)
                 return;
 
-            Dispatcher.UIThread.Post(() =>
+            DelegateActionToUiThread(new(() =>
             {
                 _overlayWindow?.ApplyPositionOnScreen(_parentWindow, position);
-            });
+            }));
         }
 
         private void CloseOverlayWindow()
         {
-            Dispatcher.UIThread.Post(() =>
+            DelegateActionToUiThread(new(() =>
             {
                 if (_overlayWindow != null)
                 {
                     _overlayWindow.Close();
                     _overlayWindow = null;
                 }
-            });
+            }));
+        }
+
+        private static void DelegateActionToUiThread(Action action)
+        {
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                action();
+                return;
+            }
+            Dispatcher.UIThread.Post(action);
+        }
+
+        private void Initialize()
+        {
+            if (_initialized)
+            {
+                return;
+            }
+
+            var topLevel = TopLevel;
+            if (topLevel is not null)
+            {
+                SetHost(topLevel);
+            }
+            UseOverlayWindow = true;
+
+            _initialized = true;
         }
     }
 }

--- a/src/Notification.Avalonia/AvaloniaNotificationManager.cs
+++ b/src/Notification.Avalonia/AvaloniaNotificationManager.cs
@@ -1,14 +1,14 @@
-using Avalonia;
-using Avalonia.Controls;
-using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Threading;
-using Notification.Avalonia.Controls;
-using Notification.Avalonia.Progress;
-using Notification.Core;
 using System;
 using System.Collections.Concurrent;
 using System.Threading;
 using System.Threading.Tasks;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Notification.Avalonia.Controls;
+using Notification.Avalonia.Extensions;
+using Notification.Avalonia.Progress;
+using Notification.Core;
 
 namespace Notification.Avalonia
 {
@@ -27,7 +27,7 @@ namespace Notification.Avalonia
         private Window _parentWindow;
         private NotificationOverlayWindow _overlayWindow;
         private bool _useOverlayWindow;
-        private bool _initialized;
+        private bool _initializedHost;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="AvaloniaNotificationManager"/> class.
@@ -46,14 +46,26 @@ namespace Notification.Avalonia
         {
             _config = config;
             _events = events;
+
+            _useOverlayWindow = true;
         }
 
         /// <summary>
         /// Attach the notification manager to a TopLevel (Window or similar).
         /// Must be called before showing notifications.
         /// </summary>
-        public void SetHost(TopLevel host)
+        public void SetHost(TopLevel host, bool init = false)
         {
+            if (init)
+            {
+                host = TopLevel;
+                if (host is null)
+                {
+                    return;
+                }
+                _initializedHost = true;
+            }
+            
             _parentWindow = host as Window;
 
             _host = new AvaloniaNotificationHost(host)
@@ -99,6 +111,10 @@ namespace Notification.Avalonia
         {
             get
             {
+                if (!_initializedHost)
+                {
+                    SetHost(null, init: true);
+                }
                 if (_useOverlayWindow)
                 {
                     EnsureOverlayWindow();
@@ -160,8 +176,6 @@ namespace Notification.Avalonia
         public Guid ShowCustomContent(Control content, TimeSpan? expirationTime = null,
             NotificationColor? backgroundColor = null)
         {
-            Initialize();
-
             AvaloniaNotificationHost host = ActiveHost;
             if (host == null)
             {
@@ -188,8 +202,6 @@ namespace Notification.Avalonia
         /// </summary>
         public Guid Show(NotificationRequest request)
         {
-            Initialize();
-
             Guid id = request.Id;
 
             AvaloniaNotificationHost host = ActiveHost;
@@ -228,7 +240,6 @@ namespace Notification.Avalonia
             bool showCancelButton = false,
             string waitingMessage = null)
         {
-            Initialize();
             AvaloniaNotificationHost host = ActiveHost;
             if (host == null)
             {
@@ -293,7 +304,7 @@ namespace Notification.Avalonia
             if (_overlayWindow != null && _overlayWindow.IsVisible)
                 return;
 
-            DelegateActionToUiThread(new(() =>
+            new Action(() =>
             {
                 if (_overlayWindow != null)
                     return;
@@ -316,7 +327,7 @@ namespace Notification.Avalonia
                 }
 
                 _overlayWindow.Show();
-            }));
+            }).InvokeOnUiThread();
         }
 
         private void RepositionOverlayWindow(NotificationPosition position)
@@ -324,49 +335,22 @@ namespace Notification.Avalonia
             if (_overlayWindow == null || _parentWindow == null)
                 return;
 
-            DelegateActionToUiThread(new(() =>
+            new Action(() =>
             {
                 _overlayWindow?.ApplyPositionOnScreen(_parentWindow, position);
-            }));
+            }).InvokeOnUiThread();
         }
 
         private void CloseOverlayWindow()
         {
-            DelegateActionToUiThread(new(() =>
+            new Action(() =>
             {
                 if (_overlayWindow != null)
                 {
                     _overlayWindow.Close();
                     _overlayWindow = null;
                 }
-            }));
-        }
-
-        private static void DelegateActionToUiThread(Action action)
-        {
-            if (Dispatcher.UIThread.CheckAccess())
-            {
-                action();
-                return;
-            }
-            Dispatcher.UIThread.Post(action);
-        }
-
-        private void Initialize()
-        {
-            if (_initialized)
-            {
-                return;
-            }
-
-            var topLevel = TopLevel;
-            if (topLevel is not null)
-            {
-                SetHost(topLevel);
-            }
-            UseOverlayWindow = true;
-
-            _initialized = true;
+            }).InvokeOnUiThread();
         }
     }
 }

--- a/src/Notification.Avalonia/AvaloniaNotificationManager.cs
+++ b/src/Notification.Avalonia/AvaloniaNotificationManager.cs
@@ -56,6 +56,7 @@ namespace Notification.Avalonia
         /// </summary>
         public void SetHost(TopLevel host, bool init = false)
         {
+            _initializedHost = true;
             if (init)
             {
                 host = TopLevel;
@@ -63,7 +64,6 @@ namespace Notification.Avalonia
                 {
                     return;
                 }
-                _initializedHost = true;
             }
             
             _parentWindow = host as Window;

--- a/src/Notification.Avalonia/AvaloniaNotificationManager.cs
+++ b/src/Notification.Avalonia/AvaloniaNotificationManager.cs
@@ -1,14 +1,14 @@
-using System;
-using System.Collections.Concurrent;
-using System.Collections.Generic;
-using System.Threading;
-using System.Threading.Tasks;
 using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
 using Avalonia.Threading;
 using Notification.Avalonia.Controls;
 using Notification.Avalonia.Progress;
 using Notification.Core;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Notification.Avalonia
 {
@@ -45,6 +45,14 @@ namespace Notification.Avalonia
         {
             _config = config;
             _events = events;
+
+            var appLifetime = (IClassicDesktopStyleApplicationLifetime)Application.Current!.ApplicationLifetime!;
+            var win = appLifetime?.MainWindow;
+            if (win is not null)
+            {
+                SetHost(win);
+            }
+            UseOverlayWindow = true;
         }
 
         /// <summary>
@@ -268,7 +276,7 @@ namespace Notification.Avalonia
             if (_overlayWindow != null && _overlayWindow.IsVisible)
                 return;
 
-            Dispatcher.UIThread.Post(() =>
+            void InitOverlay()
             {
                 if (_overlayWindow != null)
                     return;
@@ -284,14 +292,24 @@ namespace Notification.Avalonia
                     _overlayWindow = null;
                 };
 
+                _overlayWindow.ApplyPositionOnScreen(_parentWindow, position);
                 if (_parentWindow != null)
                 {
-                    _overlayWindow.ApplyPositionOnScreen(_parentWindow, position);
                     _overlayWindow.BindToParent(_parentWindow);
                 }
 
                 _overlayWindow.Show();
-            });
+            }
+
+            // this pattern can be used to refactor for action/func and async Tasks
+            if (Dispatcher.UIThread.CheckAccess())
+            {
+                InitOverlay();
+            }
+            else
+            {
+                Dispatcher.UIThread.Post(InitOverlay);
+            }
         }
 
         private void RepositionOverlayWindow(NotificationPosition position)

--- a/src/Notification.Avalonia/Controls/AvaloniaNotificationHost.cs
+++ b/src/Notification.Avalonia/Controls/AvaloniaNotificationHost.cs
@@ -14,6 +14,7 @@ using Avalonia.Media;
 using Avalonia.Media.Imaging;
 using Avalonia.Styling;
 using Avalonia.Threading;
+using Notification.Avalonia.Extensions;
 using Notification.Core;
 
 namespace Notification.Avalonia.Controls
@@ -205,7 +206,7 @@ namespace Notification.Avalonia.Controls
         {
             Guid id = request.Id;
 
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 EnsureAttached();
                 EnforceMaxItems();
@@ -218,7 +219,7 @@ namespace Notification.Avalonia.Controls
                 AnimateShow(card);
 
                 StartDismissTimer(id, expiration);
-            });
+            }).InvokeOnUiThread();
 
             return id;
         }
@@ -231,7 +232,7 @@ namespace Notification.Avalonia.Controls
             Guid id = Guid.NewGuid();
             ProgressCardHandle handle = new ProgressCardHandle(id);
 
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 EnsureAttached();
                 EnforceMaxItems();
@@ -242,7 +243,7 @@ namespace Notification.Avalonia.Controls
                 AddCardToPanel(card);
                 UpdateHitTest();
                 AnimateShow(card);
-            });
+            }).InvokeOnUiThread();
 
             return handle;
         }
@@ -254,7 +255,7 @@ namespace Notification.Avalonia.Controls
         {
             Guid id = Guid.NewGuid();
 
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 EnsureAttached();
                 EnforceMaxItems();
@@ -283,7 +284,7 @@ namespace Notification.Avalonia.Controls
                 AnimateShow(card);
 
                 StartDismissTimer(id, expiration);
-            });
+            }).InvokeOnUiThread();
 
             return id;
         }
@@ -310,13 +311,13 @@ namespace Notification.Avalonia.Controls
         /// </summary>
         public void CloseAll()
         {
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 // Immediate close for "dismiss all" — no animation
                 _cards.Clear();
                 _panel.Children.Clear();
                 UpdateHitTest();
-            });
+            }).InvokeOnUiThread();
         }
 
         private static async void AnimateShow(Border card)
@@ -824,7 +825,7 @@ namespace Notification.Avalonia.Controls
         /// </summary>
         public void UpdateProgress(double? value, string message, string title, bool? showCancel)
         {
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 if (value.HasValue)
                 {
@@ -845,7 +846,7 @@ namespace Notification.Avalonia.Controls
 
                 if (showCancel.HasValue && _cancelButton != null)
                     _cancelButton.IsVisible = showCancel.Value;
-            });
+            }).InvokeOnUiThread();
         }
 
         /// <summary>
@@ -853,12 +854,12 @@ namespace Notification.Avalonia.Controls
         /// </summary>
         public void UpdateWaitingTime(string text)
         {
-            Dispatcher.UIThread.Post(() =>
+            new Action(() =>
             {
                 if (_waitingBlock == null) return;
                 _waitingBlock.Text = text ?? "";
                 _waitingBlock.IsVisible = !string.IsNullOrEmpty(text);
-            });
+            }).InvokeOnUiThread();
         }
 
         /// <summary>

--- a/src/Notification.Avalonia/Controls/NotificationOverlayWindow.cs
+++ b/src/Notification.Avalonia/Controls/NotificationOverlayWindow.cs
@@ -102,13 +102,13 @@ namespace Notification.Avalonia.Controls
         /// </summary>
         public void ApplyPositionOnScreen(Window parentWindow, NotificationPosition position)
         {
-            if (parentWindow?.Screens == null)
-                return;
+            var screens = parentWindow?.Screens ?? Screens;
 
-            Screen targetScreen = parentWindow.Screens.ScreenFromWindow(parentWindow)
-                                  ?? parentWindow.Screens.Primary;
+            var targetScreen = parentWindow is not null
+                    ? screens?.ScreenFromWindow(parentWindow) ?? screens?.Primary
+                    : screens?.Primary;
 
-            if (targetScreen == null)
+            if (targetScreen is null)
                 return;
 
             PixelRect workArea = targetScreen.WorkingArea;

--- a/src/Notification.Avalonia/Extensions/ActionExtensions.cs
+++ b/src/Notification.Avalonia/Extensions/ActionExtensions.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Threading.Tasks;
+using Avalonia.Threading;
+
+namespace Notification.Avalonia.Extensions;
+
+/// <summary>
+/// Provides extension methods for <see cref="Action"/> and asynchronous delegates executed on the UI thread.
+/// </summary>
+public static class ActionExtensions
+{
+    /// <summary>
+    /// Executes the action immediately if already on the UI thread;
+    /// otherwise posts it to the UI dispatcher.
+    /// </summary>
+    public static void InvokeOnUiThread(this Action action)
+    {
+        if (action is null)
+            return;
+
+        if (Dispatcher.UIThread.CheckAccess())
+        {
+            action();
+            return;
+        }
+
+        Dispatcher.UIThread.Post(action);
+    }
+
+    /// <summary>
+    /// Executes the asynchronous action on the UI thread.
+    /// </summary>
+    public static void InvokeOnUiThreadAsync(this Func<Task> action)
+    {
+        if (action is null)
+            return;
+
+        Dispatcher.UIThread.Post(async () =>
+        {
+            await action();
+        });
+    }
+}

--- a/src/Notification.Avalonia/Notification.Avalonia.xml
+++ b/src/Notification.Avalonia/Notification.Avalonia.xml
@@ -41,6 +41,11 @@
             Gets the currently active notification host (in-window or overlay).
             </summary>
         </member>
+        <member name="P:Notification.Avalonia.AvaloniaNotificationManager.TopLevel">
+            <summary>
+            Gets the top Level Avalonia control, platform agnostic (desktop or mobile/browser).
+            </summary>
+        </member>
         <member name="P:Notification.Avalonia.AvaloniaNotificationManager.Position">
             <summary>
             Gets or sets the notification position. Can be changed at runtime.

--- a/src/Notification.Avalonia/Notification.Avalonia.xml
+++ b/src/Notification.Avalonia/Notification.Avalonia.xml
@@ -23,7 +23,7 @@
             <param name="config">The notification configuration.</param>
             <param name="events">The event service used to raise lifecycle events.</param>
         </member>
-        <member name="M:Notification.Avalonia.AvaloniaNotificationManager.SetHost(Avalonia.Controls.TopLevel)">
+        <member name="M:Notification.Avalonia.AvaloniaNotificationManager.SetHost(Avalonia.Controls.TopLevel,System.Boolean)">
             <summary>
             Attach the notification manager to a TopLevel (Window or similar).
             Must be called before showing notifications.
@@ -212,6 +212,22 @@
             <summary>
             Position the overlay window on the correct edge of the screen
             based on the current notification position.
+            </summary>
+        </member>
+        <member name="T:Notification.Avalonia.Extensions.ActionExtensions">
+            <summary>
+            Provides extension methods for <see cref="T:System.Action"/> and asynchronous delegates executed on the UI thread.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.Extensions.ActionExtensions.InvokeOnUiThread(System.Action)">
+            <summary>
+            Executes the action immediately if already on the UI thread;
+            otherwise posts it to the UI dispatcher.
+            </summary>
+        </member>
+        <member name="M:Notification.Avalonia.Extensions.ActionExtensions.InvokeOnUiThreadAsync(System.Func{System.Threading.Tasks.Task})">
+            <summary>
+            Executes the asynchronous action on the UI thread.
             </summary>
         </member>
         <member name="T:Notification.Avalonia.Progress.AvaloniaNotifierProgress">

--- a/src/Notification.Avalonia/Progress/AvaloniaNotifierProgress.cs
+++ b/src/Notification.Avalonia/Progress/AvaloniaNotifierProgress.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Diagnostics;
 using System.Threading;
-using Avalonia.Threading;
 using Notification.Avalonia.Controls;
+using Notification.Avalonia.Extensions;
 using Notification.Core;
 
 namespace Notification.Avalonia.Progress
@@ -90,7 +90,7 @@ namespace Notification.Avalonia.Progress
 
             try
             {
-                Dispatcher.UIThread.Post(() => _handle.Close());
+                new Action(() => _handle.Close()).InvokeOnUiThread();
                 _waitingTimer.Dispose();
                 CancelSource?.Dispose();
             }


### PR DESCRIPTION
Following up on issue #82, I tried using Avalonia notifications, but it didn't work. 
Rather than opening a new issue to explain what goes wrong, I found solutions to several issues I encountered.

Step 1 and 2 for use case.

1) **Setup DI service**
```csharp
sc.AddAvaloniaNotifications(cfg =>
{
    cfg.SuccessBackgroundColor = NotificationColor.FromHex("#FF252525");
    cfg.ErrorBackgroundColor = NotificationColor.FromHex("#FF252525");
    cfg.SuccessIconColor = NotificationColor.LimeGreen;
    cfg.ErrorIconColor = NotificationColor.OrangeRed;
    cfg.DefaultExpirationTime = TimeSpan.FromSeconds(5);
})
```
2) Call **Show** method using **INotificationService** interface
 _we shouldn't know anything about manager that add a framework dependency if called outside.._

```csharp
sp.GetRequiredService<INotificationService>()
   .Show(new() { Title = "title", Message = "message", Type = NotificationType.Success, ShowCloseButton = false });
```

3) What comes with the PR ?

- Fix default position without parent window associated.
- Fix DI / service use (no need to instantiate a manager before first show call) 
- UseOverlayWindow as default like WPF imp (debatable, can be in the notif request aswell)
- Automatically set the main window as host if instanciated.

This also fix my implementation of your package in my Xiletrade project :
https://github.com/maxensas/xiletrade/blob/dev/src/Xiletrade.UI.Avalonia/Program.cs

4) Possible area for improvement : refactor Dispatcher.UIThread calls and make async Tasks.
```csharp
if (Dispatcher.UIThread.CheckAccess())
{
    InitOverlay();
}
else
{
    Dispatcher.UIThread.Post(InitOverlay);
}
```
This allow _overlayWindow to be instancied when calling Show method (it works because already in UI thread but would be better to await using Task)